### PR TITLE
only remove msvc10 64bits builds if appveyor flags is set to true

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ You specify another remote name with parameter **remote**.
 - **use_docker**: Use docker for package creation in Linux systems.
 - **curpage**: Current page of packages to create
 - **total_pages**: Total of pages
+- **appveyor**: Flag to tell that we are using an AppVeyor or Travis CI engine that cannot build for VS10 64bits. Default [True]
 
 Upload related parameters:
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ You specify another remote name with parameter **remote**.
 - **use_docker**: Use docker for package creation in Linux systems.
 - **curpage**: Current page of packages to create
 - **total_pages**: Total of pages
-- **appveyor**: Flag to tell that we are using an AppVeyor or Travis CI engine that cannot build for VS10 64bits. Default [True]
+- **vs10_x86_64_enabled**: Flag to tell that wether to build for VS10 64bits. Default [False]
 
 Upload related parameters:
 

--- a/conan/packager.py
+++ b/conan/packager.py
@@ -21,7 +21,7 @@ class ConanMultiPackager(object):
                  use_docker=None, curpage=None, total_pages=None,
                  reference=None, password=None, remote=None,
                  upload=None, stable_branch_pattern=None,
-                 appveyor=True):
+                 vs10_x86_64_enabled=False):
         self.builds = []
         self.runner = runner or os.system
         self.logger = logger
@@ -58,7 +58,7 @@ class ConanMultiPackager(object):
             self.password = self.password.replace('"', '\\"')
 
         self.conan_pip_package = os.getenv("CONAN_PIP_PACKAGE", None)
-        self.appveyor = appveyor
+        self.vs10_x86_64_enabled = vs10_x86_64_enabled
 
     def _execute_test(self, precommand, settings, options):
         settings = collections.OrderedDict(sorted(settings.items()))
@@ -92,7 +92,7 @@ class ConanMultiPackager(object):
         if platform.system() == "Windows":
             for visual_version in self.visual_versions:
                 for arch in ["x86", "x86_64"]:
-                    if self.appveyor and arch == "x86_64" and visual_version == 10:  # Not available even in Appveyor
+                    if not self.vs10_x86_64_enabled and arch == "x86_64" and visual_version == 10:
                         continue
                     self._add_visual_builds(visual_version, arch, shared_option_name)
         elif platform.system() == "Linux":

--- a/conan/packager.py
+++ b/conan/packager.py
@@ -20,7 +20,8 @@ class ConanMultiPackager(object):
                  gcc_versions=None, visual_versions=None, apple_clang_versions=None,
                  use_docker=None, curpage=None, total_pages=None,
                  reference=None, password=None, remote=None,
-                 upload=None, stable_branch_pattern=None):
+                 upload=None, stable_branch_pattern=None,
+                 appveyor=True):
         self.builds = []
         self.runner = runner or os.system
         self.logger = logger
@@ -57,6 +58,7 @@ class ConanMultiPackager(object):
             self.password = self.password.replace('"', '\\"')
 
         self.conan_pip_package = os.getenv("CONAN_PIP_PACKAGE", None)
+        self.appveyor = appveyor
 
     def _execute_test(self, precommand, settings, options):
         settings = collections.OrderedDict(sorted(settings.items()))
@@ -90,7 +92,7 @@ class ConanMultiPackager(object):
         if platform.system() == "Windows":
             for visual_version in self.visual_versions:
                 for arch in ["x86", "x86_64"]:
-                    if arch == "x86_64" and visual_version == 10:  # Not available even in Appveyor
+                    if self.appveyor and arch == "x86_64" and visual_version == 10:  # Not available even in Appveyor
                         continue
                     self._add_visual_builds(visual_version, arch, shared_option_name)
         elif platform.system() == "Linux":


### PR DESCRIPTION
Added a flag to say that we are in Appveyor mode and we need to remove "visual_studio"/"10"/"x86_64" builds
its true by default so it keeps the same workflow by default.

We need this because our internal CI can build these builds