### PR TITLE
Allow to select visual runtimes

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ You specify another remote name with parameter **remote**.
 - **gcc_versions**: List with a subset of gcc_versions. Default ["4.6", "4.8", "4.9", "5.2", "5.3"]
 - **apple_clang_versions**: List with a subset of apple-clang versions. Default ["5.0", "5.1", "6.0", "6.1", "7.0"]
 - **visual_versions**: List with a subset of visual studio versions. Default [10, 12, 14]
-- **visual_runtimes**: List containing visual studio runtimes to use in builds. Default ["MT, "MD]
+- **visual_runtimes**: List containing visual studio runtimes to use in builds. Default ["MT", "MD", "MTd", "MDd"]
 - **use_docker**: Use docker for package creation in Linux systems.
 - **curpage**: Current page of packages to create
 - **total_pages**: Total of pages

--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ You specify another remote name with parameter **remote**.
 - **gcc_versions**: List with a subset of gcc_versions. Default ["4.6", "4.8", "4.9", "5.2", "5.3"]
 - **apple_clang_versions**: List with a subset of apple-clang versions. Default ["5.0", "5.1", "6.0", "6.1", "7.0"]
 - **visual_versions**: List with a subset of visual studio versions. Default [10, 12, 14]
+- **visual_runtimes**: List containing visual studio runtimes to use in builds. Default ["MT, "MD]
 - **use_docker**: Use docker for package creation in Linux systems.
 - **curpage**: Current page of packages to create
 - **total_pages**: Total of pages
@@ -171,6 +172,7 @@ It's specially useful for CI integration.
 - **CONAN_GCC_VERSIONS**: Gcc versions comma separated, EX: "4.6,4.8,5.2"
 - **CONAN_APPLE_CLANG_VERSIONS**: Apple clang versions comma separated, EX: "5.0,5.1"
 - **CONAN_VISUAL_VERSIONS**: Visual versions, comma separated, EX: "12,14"
+- **CONAN_VISUAL_RUNTIMES**: Visual runtimes, comma separated, Ex: "MT,MD"
 - **CONAN_USE_DOCKER**: If defined will use docker
 - **CONAN_CURRENT_PAGE**:  Current page of packages to create
 - **CONAN_TOTAL_PAGES**: Total of pages

--- a/conan/packager.py
+++ b/conan/packager.py
@@ -14,7 +14,7 @@ class ConanMultiPackager(object):
     and run conan test command in docker containers"""
     default_gcc_versions = ["4.6", "4.8", "4.9", "5.2", "5.3"]
     default_visual_versions = [10, 12, 14]
-    default_visual_runtimes = ["MT", "MD"]
+    default_visual_runtimes = ["MT", "MD", "MTd", "MDd"]
     default_apple_clang_versions = ["5.0", "5.1", "6.0", "6.1", "7.0"]
 
     def __init__(self, args=None, username=None, channel=None, runner=None,
@@ -115,23 +115,28 @@ class ConanMultiPackager(object):
             if "MT" in self.visual_runtimes:
                 sets.append([{"build_type": "Release", "compiler.runtime": "MT"},
                              {shared_option_name: False}])
+            if "MTd" in self.visual_runtimes:
                 sets.append([{"build_type": "Debug", "compiler.runtime": "MTd"},
                              {shared_option_name: False}])
             if "MD" in self.visual_runtimes:
-                sets.append([{"build_type": "Debug", "compiler.runtime": "MDd"},
+                sets.append([{"build_type": "Release", "compiler.runtime": "MD"},
                              {shared_option_name: False}])
                 sets.append([{"build_type": "Release", "compiler.runtime": "MD"},
+                             {shared_option_name: True}])
+            if "MDd" in self.visual_runtimes:
+                sets.append([{"build_type": "Debug", "compiler.runtime": "MDd"},
                              {shared_option_name: False}])
                 sets.append([{"build_type": "Debug", "compiler.runtime": "MDd"},
                              {shared_option_name: True}])
-                sets.append([{"build_type": "Release", "compiler.runtime": "MD"},
-                             {shared_option_name: True}])
+
         else:
             if "MT" in self.visual_runtimes:
                 sets.append([{"build_type": "Release", "compiler.runtime": "MT"}, {}])
+            if "MTd" in self.visual_runtimes:
                 sets.append([{"build_type": "Debug", "compiler.runtime": "MTd"}, {}])
-            if "MD" in self.visual_runtimes:
+            if "MDd" in self.visual_runtimes:
               sets.append([{"build_type": "Debug", "compiler.runtime": "MDd"}, {}])
+            if "MD" in self.visual_runtimes:
               sets.append([{"build_type": "Release", "compiler.runtime": "MD"}, {}])
 
         for setting, options in sets:


### PR DESCRIPTION
We don't need the MT builds to happen in our CI, but there wasn't a way to say which runtime to use, this should allow a user to override defaults