### PR TITLE
Added minimal Jenkins CI support to the packager.

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,6 +398,15 @@ When building from bamboo several environement variables get set during builds.
  
 If the env var **bamboo_buildNumber** is set and the branch name (**bamboo_planRepository_branch** env var) matches **stable_branch_pattern** then the channel name gets set to ```stable```.
 
+## Jenkins CI integration
+
+[Jenkins](https://jenkins.io/) is an open source CI tool that was originally forked from hudson.
+When building from jenkins several environement variables get set during builds.
+ 
+If the env var **JENKINS_URL** is set and the branch name (**BRANCH_NAME** env var) matches **stable_branch_pattern** then the channel name gets set to ```stable```.
+
+Currently only the pipeline builds set the **BRANCH_NAME** env var automatically.
+
 # Full example
 
 You can see the full zlib example [here](https://github.com/lasote/conan-zlib)

--- a/conan/packager.py
+++ b/conan/packager.py
@@ -401,11 +401,14 @@ class ConanMultiPackager(object):
         appveyor_branch = os.getenv("APPVEYOR_REPO_BRANCH", None)
         bamboo = os.getenv("bamboo_buildNumber", False)
         bamboo_branch = os.getenv("bamboo_planRepository_branch", None)
+        jenkins = os.getenv("JENKINS_URL", False)
+        jenkins_branch = os.getenv("BRANCH_NAME", None)
 
         channel = "stable" if travis and prog.match(travis_branch) else None
         channel = "stable" if appveyor and prog.match(appveyor_branch) and \
             not os.getenv("APPVEYOR_PULL_REQUEST_NUMBER") else channel
         channel = "stable" if bamboo and prog.match(bamboo_branch) else channel
+        channel = "stable" if jenkins and prog.match(jenkins_branch) else channel
 
         ret = channel or default_channel or os.getenv("CONAN_CHANNEL", "testing")
         if ret != os.getenv("CONAN_CHANNEL", "testing"):


### PR DESCRIPTION
This currently only works automatically with jenkins 2.0 pipeline builds since jenkins just started setting the BRANCH_NAME env var.  The variable name used to be different depending on which version control was used.