### PR TITLE
Make '--all' argument conditional for conan upload

### DIFF
--- a/conan/packager.py
+++ b/conan/packager.py
@@ -332,7 +332,7 @@ class ConanMultiPackager(object):
         self.remote = remote
         self._upload_packages()
 
-    def _upload_packages(self):
+    def _upload_packages(self, upload_all=True):
         """
         :param password: If it has double quotes, they must not be escaped, this function
         does escaping of double quotes automatically. It is supposed that this password
@@ -344,9 +344,11 @@ class ConanMultiPackager(object):
             self.logger.info("Skipped upload, some parameter (reference, password or channel)"
                              " is missing!")
             return
-        command = "conan upload %s@%s/%s --all --force" % (self.reference,
-                                                           self.username,
-                                                           self.channel)
+        command = "conan upload %s@%s/%s %s --force" % (self.reference,
+                                                        self.username,
+                                                        self.channel,
+                                                        '--all' if upload_all else ''
+                                                        )
         user_command = 'conan user %s -p="%s"' % (self.username, self.password)
 
         self.logger.info("******** RUNNING UPLOAD COMMAND ********** \n%s" % command)


### PR DESCRIPTION
Let the upload method have an argument to select whether to upload all, recipe + package, or only recipe. 

Motto: https://github.com/conan-io/conan-package-tools/issues/25
