### PR TITLE
appveyor: prepend PYTHON to PATH to respect environment setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,7 +398,7 @@ This is very similar to Travis CI. With the same **build.py** script we have the
     build: false
     environment:
         PYTHON: "C:\\Python27-x64"
-        PYTHON_VERSION: "2.7.11"
+        PYTHON_VERSION: "2.7.x"
         PYTHON_ARCH: "64"
 
         CONAN_UPLOAD: 1
@@ -414,13 +414,12 @@ This is very similar to Travis CI. With the same **build.py** script we have the
             - CONAN_CURRENT_PAGE: 3
             - CONAN_CURRENT_PAGE: 4
     install:
-      - set PATH=%PATH%;%PYTHON%/Scripts/
+      - set PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%
       - pip.exe install conan_package_tools # It install conan too
       - conan user # It creates the conan data directory
 
     test_script:
-      - python build.py
-
+      - python build.py
 
 
 - Remember to set the **CONAN_PASSWORD** variable in appveyor build backoffice!


### PR DESCRIPTION
AFAIK while the script specifies 2.7.11 x64, it is being run with the default in PATH [1] - 2.7.13 x86.

Prepend PYTHON to PATH to respect setting.

Fix PYTHON_VERSION minor to "x" as it is not constant on Python27-x64.

[1] https://www.appveyor.com/docs/build-environment/#python 