### PR TITLE
Add support for named pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,18 +124,47 @@ Or passing a list to ConanMultiPackager constructor:
 
 ## Pagination
 
-You can launch partial builds passing two pagination parameters, **curpage** and **total_pages**.
-This is very useful with CI servers like Travis, because you can split the builds in pages, just by passing some parameters:
+You can split builds in pages, this is very useful with CI servers like Travis to obey job time limit or just segment specific build configurations.
+
+There are two ways of setting pagination.
+
+**Named pages**
+
+By adding builds to the **named_builds** dictionary, and passing **curpage** with the page name: 
+
+    from conan.packager import ConanMultiPackager
+    from collections import defaultdict
+
+    if __name__ == '__main__':
+        builder = ConanMultiPackager(curpage="x86", total_pages=2)
+        named_builds = defaultdict(list)
+        builder.add_common_builds(shared_option_name="bzip2:shared", pure_c=True)
+        for settings, options, env_vars, build_requires in builder.builds:
+            named_builds[settings['arch']].append([settings, options, env_vars, build_requires])
+        builder.named_builds = named_builds
+        builder.run()
+
+named_builds not have a dictionary entry for x86 and another for x86_64:
+
+- for **curpage="x86"** it would do all x86 builds
+- for **curpage="x86_64"** it would do all x86_64 builds
+
+**Sequencial distribution**
+
+By simply passing two pagination parameters, **curpage** and **total_pages**:
 
     from conan.packager import ConanMultiPackager
 
     if __name__ == "__main__":
-        builder = ConanMultiPackager(curpage=1, total_pages=2)
+        builder = ConanMultiPackager(curpage=1, total_pages=3)
         builder.add_common_builds(shared_option_name="bzip2:shared", pure_c=True)
         builder.run()
 
-If you added 10 package's to the builder, each page will execute 1 package generation, so in the example above will create the first 5 packages.
+If you added 10 package's to the builder:
 
+- for **curpage=1** it would do builds 1,4,7,10
+- for **curpage=2** it would do builds 2,5,8
+- for **curpage=3** it would do builds 3,6,9
 
 ## Docker pack
 

--- a/conan/packager.py
+++ b/conan/packager.py
@@ -54,6 +54,7 @@ class ConanMultiPackager(object):
                  upload_retry=None):
 
         self._builds = []
+        self._named_builds = {}
         self._platform_info = platform_info or PlatformInfo()
         self.runner = runner or os.system
         self.args = args or " ".join(sys.argv[1:])
@@ -117,6 +118,7 @@ class ConanMultiPackager(object):
     @builds.setter
     def builds(self, confs):
         """For retrocompatibility directly assigning builds"""
+        self._named_builds = {}
         self._builds = []
         for values in confs:
             if len(values) == 2:
@@ -126,6 +128,24 @@ class ConanMultiPackager(object):
                                 "(settings, options, env_vars, build_requires)")
             else:
                 self._builds.append(BuildConf(*values))
+
+    @property
+    def named_builds(self):
+        return self._named_builds
+
+    @named_builds.setter
+    def named_builds(self, confs):
+        self._builds = []
+        self._named_builds = {}
+        for key, pages in confs.items():
+            for values in pages:
+                if len(values) == 2:
+                    self._named_builds.setdefault(key,[]).append(BuildConf(values[0], values[1], {}, {}))
+                elif len(values) != 4:
+                    raise Exception("Invalid build configuration, has to be a tuple of "
+                                    "(settings, options, env_vars, build_requires)")
+                else:
+                    self._named_builds.setdefault(key,[]).append(BuildConf(*values))
 
     def add_common_builds(self, shared_option_name=None, pure_c=True, dll_with_static_runtime=False):
 
@@ -155,14 +175,28 @@ class ConanMultiPackager(object):
         self.upload_packages()
 
     def run_builds(self, curpage=None, total_pages=None):
-        curpage = curpage or int(self.curpage)
-        total_pages = total_pages or int(self.total_pages)
+        if len(self.named_builds) > 0 and len(self.builds) > 0:
+            raise Exception("Both bulk and named builds are set. Only one is allowed.")
+
         self.runner('conan export %s/%s' % (self.username, self.channel))
 
         builds_in_current_page = []
-        for index, build in enumerate(self.builds):
-            if curpage is None or total_pages is None or (index % total_pages) + 1 == curpage:
+        if len(self.builds) > 0:
+            curpage = curpage or int(self.curpage)
+            total_pages = total_pages or int(self.total_pages)
+            for index, build in enumerate(self.builds):
+                if curpage is None or total_pages is None or (index % total_pages) + 1 == curpage:
+                    builds_in_current_page.append(build)
+        elif len(self.named_builds) > 0:
+            curpage = curpage or self.curpage
+            if curpage not in self.named_builds:
+                raise Exception("No builds set for page " + curpage)
+            for build in self.named_builds[curpage]:
                 builds_in_current_page.append(build)
+
+        print("Page       : ", curpage)
+        print("Builds list:")
+        for p in builds_in_current_page: print(list(p._asdict().items()))
 
         pulled_gcc_images = defaultdict(lambda: False)
         for build in builds_in_current_page:
@@ -282,5 +316,3 @@ if __name__ == "__main__":
     builder.add_common_builds(pure_c=False)
     builder.add(build_requires={"*": ["uno/1.0@lasote/stable", "dos/0.1@lasote/testing"]})
     builder.run()
-
-

--- a/conan/test/packager_test.py
+++ b/conan/test/packager_test.py
@@ -1,6 +1,8 @@
 import platform
 import unittest
 
+from collections import defaultdict
+
 from conan.builds_generator import BuildConf
 from conan.packager import ConanMultiPackager
 from conans.model.ref import ConanFileReference
@@ -148,4 +150,18 @@ class AppTest(unittest.TestCase):
                      {},
                      {'*': [ConanFileReference.loads("mingw_installer/0.1@lasote/testing")]})]
         self.assertEquals([tuple(a) for a in builder.builds], expected)
+
+    def test_named_pages(self):
+        builder = ConanMultiPackager(username="Pepe")
+        named_builds = defaultdict(list)
+        builder.add_common_builds(shared_option_name="zlib:shared", pure_c=True)
+        for settings, options, env_vars, build_requires in builder.builds:
+            named_builds[settings['arch']].append([settings, options, env_vars, build_requires])
+        builder.named_builds = named_builds
+
+        self.assertEquals(builder.builds, [])
+        self.assertEquals(len(builder.named_builds), 2)
+        self.assertTrue("x86" in builder.named_builds)
+        self.assertTrue("x86_64" in builder.named_builds)
+
 


### PR DESCRIPTION
After #63 suggestion.

This creates support for named pages. For example to split x86 and x86_64 buils in two pages it would be enough to use this code on build.py:

```
named_builds = {'x86': [], 'x86_64': []}
for settings, options, env_vars, build_requires in builder.builds:
        named_builds[settings['arch']].append([settings, options, env_vars, build_requires])
builder.builds = []
builder.named_builds = named_builds
```
And then setting CONAN_CURRENT_PAGE with the page name:

`CONAN_CURRENT_PAGE=x86`

In this case CONAN_TOTAL_PAGES is ignored.

Will wait for review/suggestions before adding documentation.

