### PR TITLE
Fix default libcxx for Clang build

### DIFF
--- a/conan/builds_generator.py
+++ b/conan/builds_generator.py
@@ -192,7 +192,7 @@ def get_linux_clang_builds(clang_versions, archs, shared_option_name, pure_c):
                         ret.append(get_build("clang", arch, build_type, clang_version,
                                              "libstdc++"))
                         ret.append(get_build("clang", arch, build_type, clang_version,
-                                             "libstdc++"))
+                                             "libc++"))
                     else:
                         ret.append(get_build("clang", arch, build_type, clang_version))
     return ret


### PR DESCRIPTION
Hey guys, I made a mistake with ctrl-c ctrl-v, sorry about that.

I just saw this issue in my Travis job, some minutes ago: https://travis-ci.org/uilianries/conan-catch/jobs/242799212

I'm trying to figure out how the tests passed successfully before.