### PR TITLE
Add build_type settings in ConanMultiPackager

### DIFF
--- a/README.md
+++ b/README.md
@@ -548,7 +548,7 @@ If the env var **GITLAB_CI** is set and the branch name (**CI_BUILD_REF_NAME** e
 - **remotes**: List of URLs separated by "," for the additional remotes (read).
 - **upload**: URL of the repository where we want to use to upload the packages.
 - **upload_only_when_stable**: Will try to upload only if the channel is the stable channel
-- **build_type**: List containing specific build types. Default ["Release", "Debug"]
+- **build_types**: List containing specific build types. Default ["Release", "Debug"]
 
 Upload related parameters:
 
@@ -578,7 +578,7 @@ This is especially useful for CI integration.
 - **CONAN_CLANG_VERSIONS**: Clang versions, comma separated, e.g. "3.8,3.9,4.0"
 - **CONAN_APPLE_CLANG_VERSIONS**: Apple clang versions, comma separated, e.g. "6.1,8.0"
 - **CONAN_ARCHS**: Architectures to build for, comma separated, e.g. "x86,x86_64"
-- **CONAN_BUILD_TYPE**: Build types to build for, comma separated, e.g. "Release,Debug"
+- **CONAN_BUILD_TYPES**: Build types to build for, comma separated, e.g. "Release,Debug"
 - **CONAN_VISUAL_VERSIONS**: Visual versions, comma separated, e.g. "12,14"
 - **CONAN_VISUAL_RUNTIMES**: Visual runtimes, comma separated, e.g. "MT,MD"
 - **CONAN_USE_DOCKER**: If defined will use docker

--- a/README.md
+++ b/README.md
@@ -548,6 +548,7 @@ If the env var **GITLAB_CI** is set and the branch name (**CI_BUILD_REF_NAME** e
 - **remotes**: List of URLs separated by "," for the additional remotes (read).
 - **upload**: URL of the repository where we want to use to upload the packages.
 - **upload_only_when_stable**: Will try to upload only if the channel is the stable channel
+- **build_type**: List containing specific build types. Default ["Release", "Debug"]
 
 Upload related parameters:
 
@@ -577,6 +578,7 @@ This is especially useful for CI integration.
 - **CONAN_CLANG_VERSIONS**: Clang versions, comma separated, e.g. "3.8,3.9,4.0"
 - **CONAN_APPLE_CLANG_VERSIONS**: Apple clang versions, comma separated, e.g. "6.1,8.0"
 - **CONAN_ARCHS**: Architectures to build for, comma separated, e.g. "x86,x86_64"
+- **CONAN_BUILD_TYPE**: Build types to build for, comma separated, e.g. "Release,Debug"
 - **CONAN_VISUAL_VERSIONS**: Visual versions, comma separated, e.g. "12,14"
 - **CONAN_VISUAL_RUNTIMES**: Visual runtimes, comma separated, e.g. "MT,MD"
 - **CONAN_USE_DOCKER**: If defined will use docker

--- a/conan/builds_generator.py
+++ b/conan/builds_generator.py
@@ -4,7 +4,7 @@ from collections import namedtuple
 BuildConf = namedtuple("BuildConf", "settings options env_vars build_requires")
 
 
-def get_mingw_builds(mingw_configurations, mingw_installer_reference, archs, shared_option_name):
+def get_mingw_builds(mingw_configurations, mingw_installer_reference, archs, shared_option_name, build_type):
     builds = []
     for config in mingw_configurations:
         version, arch, exception, thread = config
@@ -21,27 +21,27 @@ def get_mingw_builds(mingw_configurations, mingw_installer_reference, archs, sha
             for shared in [True, False]:
                 opt = copy.copy(options)
                 opt[shared_option_name] = shared
-                builds += _make_mingw_builds(settings, opt, build_requires)
+                builds += _make_mingw_builds(settings, opt, build_requires, build_type)
         else:
-            builds += _make_mingw_builds(settings, options, build_requires)
+            builds += _make_mingw_builds(settings, options, build_requires, build_type)
 
     return builds
 
 
-def _make_mingw_builds(settings, options, build_requires):
+def _make_mingw_builds(settings, options, build_requires, build_type):
     builds = []
-    settings.update({"build_type": "Release"})
-    settings.update({"compiler.libcxx": "libstdc++"})
-    builds.append(BuildConf(settings, options, {}, build_requires))
 
-    s2 = copy.copy(settings)
-    s2.update({"build_type": "Debug"})
-    builds.append(BuildConf(s2, options, {}, build_requires))
+    for build_type_it in build_type:
+        s2 = copy.copy(settings)
+        s2.update({"build_type": build_type_it})
+        s2.update({"compiler.libcxx": "libstdc++"})
+        builds.append(BuildConf(s2, options, {}, build_requires))
+
     return builds
 
 
 def get_visual_builds(visual_versions, archs, visual_runtimes, shared_option_name,
-                      dll_with_static_runtime, vs10_x86_64_enabled):
+                      dll_with_static_runtime, vs10_x86_64_enabled, build_type):
     ret = []
     for visual_version in visual_versions:
         visual_version = str(visual_version)
@@ -49,50 +49,50 @@ def get_visual_builds(visual_versions, archs, visual_runtimes, shared_option_nam
             if not vs10_x86_64_enabled and arch == "x86_64" and visual_version == "10":
                 continue
             visual_builds = get_visual_builds_for_version(visual_runtimes, visual_version, arch,
-                                                          shared_option_name, dll_with_static_runtime)
+                                                          shared_option_name, dll_with_static_runtime, build_type)
 
             ret.extend(visual_builds)
     return ret
 
 
-def get_visual_builds_for_version(visual_runtimes, visual_version, arch, shared_option_name, dll_with_static_runtime):
+def get_visual_builds_for_version(visual_runtimes, visual_version, arch, shared_option_name, dll_with_static_runtime, build_type):
     base_set = {"compiler": "Visual Studio",
                 "compiler.version": visual_version,
                 "arch": arch}
     sets = []
 
     if shared_option_name:
-        if "MT" in visual_runtimes:
+        if "MT" in visual_runtimes and "Release" in build_type:
             sets.append(({"build_type": "Release", "compiler.runtime": "MT"},
                          {shared_option_name: False}, {}, {}))
             if dll_with_static_runtime:
                 sets.append(({"build_type": "Release", "compiler.runtime": "MT"},
                              {shared_option_name: True}, {}, {}))
-        if "MTd" in visual_runtimes:
+        if "MTd" in visual_runtimes and "Debug" in build_type:
             sets.append(({"build_type": "Debug", "compiler.runtime": "MTd"},
                                   {shared_option_name: False}, {}, {}))
             if dll_with_static_runtime:
                 sets.append(({"build_type": "Debug", "compiler.runtime": "MTd"},
                                       {shared_option_name: True}, {}, {}))
-        if "MD" in visual_runtimes:
+        if "MD" in visual_runtimes and "Release" in build_type:
             sets.append(({"build_type": "Release", "compiler.runtime": "MD"},
                                   {shared_option_name: False}, {}, {}))
             sets.append(({"build_type": "Release", "compiler.runtime": "MD"},
                                   {shared_option_name: True}, {}, {}))
-        if "MDd" in visual_runtimes:
+        if "MDd" in visual_runtimes and "Debug" in build_type:
             sets.append(({"build_type": "Debug", "compiler.runtime": "MDd"},
                                   {shared_option_name: False}, {}, {}))
             sets.append(({"build_type": "Debug", "compiler.runtime": "MDd"},
                                   {shared_option_name: True}, {}, {}))
 
     else:
-        if "MT" in visual_runtimes:
+        if "MT" in visual_runtimes and "Release" in build_type:
             sets.append(({"build_type": "Release", "compiler.runtime": "MT"}, {}, {}, {}))
-        if "MTd" in visual_runtimes:
+        if "MTd" in visual_runtimes and "Debug" in build_type:
             sets.append(({"build_type": "Debug", "compiler.runtime": "MTd"}, {}, {}, {}))
-        if "MDd" in visual_runtimes:
+        if "MDd" in visual_runtimes and "Debug" in build_type:
             sets.append(({"build_type": "Debug", "compiler.runtime": "MDd"}, {}, {}, {}))
-        if "MD" in visual_runtimes:
+        if "MD" in visual_runtimes and "Release" in build_type:
             sets.append(({"build_type": "Release", "compiler.runtime": "MD"}, {}, {}, {}))
 
     ret = []
@@ -118,7 +118,7 @@ def get_build(compiler, the_arch, the_build_type, the_compiler_version, the_libc
     return BuildConf(setts, options, {}, {})
 
 
-def get_osx_apple_clang_builds(apple_clang_versions, archs, shared_option_name, pure_c):
+def get_osx_apple_clang_builds(apple_clang_versions, archs, shared_option_name, pure_c, build_type):
     ret = []
 
     # Not specified compiler or compiler version, will use the auto detected
@@ -126,75 +126,75 @@ def get_osx_apple_clang_builds(apple_clang_versions, archs, shared_option_name, 
         for arch in archs:
             if shared_option_name:
                 for shared in [True, False]:
-                    for build_type in ["Debug", "Release"]:
+                    for build_type_it in build_type:
                         if not pure_c:
-                            ret.append(get_build("apple-clang", arch, build_type, compiler_version,
+                            ret.append(get_build("apple-clang", arch, build_type_it, compiler_version,
                                                  "libc++", shared_option_name, shared))
                         else:
-                            ret.append(get_build("apple-clang", arch, build_type, compiler_version, None, shared_option_name, shared))
+                            ret.append(get_build("apple-clang", arch, build_type_it, compiler_version, None, shared_option_name, shared))
             else:
-                for build_type in ["Debug", "Release"]:
+                for build_type_it in build_type:
                     if not pure_c:
-                        ret.append(get_build("apple-clang", arch, build_type, compiler_version, "libc++"))
+                        ret.append(get_build("apple-clang", arch, build_type_it, compiler_version, "libc++"))
                     else:
-                        ret.append(get_build("apple-clang", arch, build_type, compiler_version))
+                        ret.append(get_build("apple-clang", arch, build_type_it, compiler_version))
 
     return ret
 
 
-def get_linux_gcc_builds(gcc_versions, archs, shared_option_name, pure_c):
+def get_linux_gcc_builds(gcc_versions, archs, shared_option_name, pure_c, build_type):
     ret = []
     # Not specified compiler or compiler version, will use the auto detected
     for gcc_version in gcc_versions:
         for arch in archs:
             if shared_option_name:
                 for shared in [True, False]:
-                    for build_type in ["Debug", "Release"]:
+                    for build_type_it in build_type:
                         if not pure_c:
-                            ret.append(get_build("gcc", arch, build_type, gcc_version,
+                            ret.append(get_build("gcc", arch, build_type_it, gcc_version,
                                                  "libstdc++", shared_option_name, shared))
                             if float(gcc_version) > 5:
-                                ret.append(get_build("gcc", arch, build_type, gcc_version,
+                                ret.append(get_build("gcc", arch, build_type_it, gcc_version,
                                                      "libstdc++11", shared_option_name, shared))
                         else:
-                            ret.append(get_build("gcc", arch, build_type, gcc_version,
+                            ret.append(get_build("gcc", arch, build_type_it, gcc_version,
                                                  None, shared_option_name, shared))
             else:
-                for build_type in ["Debug", "Release"]:
+                for build_type_it in build_type:
                     if not pure_c:
-                        ret.append(get_build("gcc", arch, build_type, gcc_version,
+                        ret.append(get_build("gcc", arch, build_type_it, gcc_version,
                                              "libstdc++"))
                         if float(gcc_version) > 5:
-                            ret.append(get_build("gcc", arch, build_type, gcc_version,
+                            ret.append(get_build("gcc", arch, build_type_it, gcc_version,
                                                  "libstdc++11"))
                     else:
-                        ret.append(get_build("gcc", arch, build_type, gcc_version))
+                        ret.append(get_build("gcc", arch, build_type_it, gcc_version))
     return ret
 
 
-def get_linux_clang_builds(clang_versions, archs, shared_option_name, pure_c):
+def get_linux_clang_builds(clang_versions, archs, shared_option_name, pure_c, build_type):
     ret = []
     # Not specified compiler or compiler version, will use the auto detected
     for clang_version in clang_versions:
         for arch in archs:
             if shared_option_name:
                 for shared in [True, False]:
-                    for build_type in ["Debug", "Release"]:
+                    for build_type_it in build_type:
                         if not pure_c:
-                            ret.append(get_build("clang", arch, build_type, clang_version,
+                            ret.append(get_build("clang", arch, build_type_it, clang_version,
                                                  "libstdc++", shared_option_name, shared))
-                            ret.append(get_build("clang", arch, build_type, clang_version,
+                            ret.append(get_build("clang", arch, build_type_it, clang_version,
                                                  "libc++", shared_option_name, shared))
                         else:
-                            ret.append(get_build("clang", arch, build_type, clang_version,
+                            ret.append(get_build("clang", arch, build_type_it, clang_version,
                                                  None, shared_option_name, shared))
             else:
-                for build_type in ["Debug", "Release"]:
+                for build_type_it in build_type:
                     if not pure_c:
-                        ret.append(get_build("clang", arch, build_type, clang_version,
+                        ret.append(get_build("clang", arch, build_type_it, clang_version,
                                              "libstdc++"))
-                        ret.append(get_build("clang", arch, build_type, clang_version,
+                        ret.append(get_build("clang", arch, build_type_it, clang_version,
                                              "libc++"))
                     else:
-                        ret.append(get_build("clang", arch, build_type, clang_version))
+                        ret.append(get_build("clang", arch, build_type_it, clang_version))
     return ret

--- a/conan/packager.py
+++ b/conan/packager.py
@@ -66,7 +66,7 @@ class ConanMultiPackager(object):
     default_visual_runtimes = ["MT", "MD", "MTd", "MDd"]
     default_apple_clang_versions = ["7.3", "8.0", "8.1"]
     default_archs = ["x86", "x86_64"]
-    default_build_type = ["Release", "Debug"]
+    default_build_types = ["Release", "Debug"]
 
     def __init__(self, args=None, username=None, channel=None, runner=None,
                  gcc_versions=None, visual_versions=None, visual_runtimes=None,
@@ -83,7 +83,7 @@ class ConanMultiPackager(object):
                  clang_versions=None,
                  login_username=None,
                  upload_only_when_stable=False,
-                 build_type=None):
+                 build_types=None):
 
         self._builds = []
         self._named_builds = {}
@@ -167,9 +167,9 @@ class ConanMultiPackager(object):
             list(filter(None, os.getenv("CONAN_ARCHS", "").split(","))) or \
             self.default_archs
 
-        self.build_type = build_type or \
-            list(filter(None, os.getenv("CONAN_BUILD_TYPE", "").split(","))) or \
-            self.default_build_type
+        self.build_types = build_types or \
+            list(filter(None, os.getenv("CONAN_BUILD_TYPES", "").split(","))) or \
+            self.default_build_types
 
         # If CONAN_DOCKER_IMAGE is speified, then use docker is True
         self.use_docker = use_docker or os.getenv("CONAN_USE_DOCKER", False) or (os.getenv("CONAN_DOCKER_IMAGE", None) is not None)
@@ -264,16 +264,16 @@ class ConanMultiPackager(object):
         if self._platform_info.system() == "Windows":
             if self.mingw_configurations:
                 builds = get_mingw_builds(self.mingw_configurations, self.mingw_installer_reference, self.archs,
-                                            shared_option_name, self.build_type)
+                                            shared_option_name, self.build_types)
             builds.extend(get_visual_builds(self.visual_versions, self.archs, self.visual_runtimes,
-                                            shared_option_name, dll_with_static_runtime, self.vs10_x86_64_enabled, self.build_type))
+                                            shared_option_name, dll_with_static_runtime, self.vs10_x86_64_enabled, self.build_types))
         elif self._platform_info.system() == "Linux":
-            builds = get_linux_gcc_builds(self.gcc_versions, self.archs, shared_option_name, pure_c, self.build_type)
-            builds.extend(get_linux_clang_builds(self.clang_versions, self.archs, shared_option_name, pure_c, self.build_type))
+            builds = get_linux_gcc_builds(self.gcc_versions, self.archs, shared_option_name, pure_c, self.build_types)
+            builds.extend(get_linux_clang_builds(self.clang_versions, self.archs, shared_option_name, pure_c, self.build_types))
         elif self._platform_info.system() == "Darwin":
-            builds = get_osx_apple_clang_builds(self.apple_clang_versions, self.archs, shared_option_name, pure_c, self.build_type)
+            builds = get_osx_apple_clang_builds(self.apple_clang_versions, self.archs, shared_option_name, pure_c, self.build_types)
         elif self._platform_info.system() == "FreeBSD":
-            builds = get_linux_clang_builds(self.clang_versions, self.archs, shared_option_name, pure_c, self.build_type)
+            builds = get_linux_clang_builds(self.clang_versions, self.archs, shared_option_name, pure_c, self.build_types)
 
         self.builds.extend(builds)
 

--- a/conan/packager.py
+++ b/conan/packager.py
@@ -66,6 +66,7 @@ class ConanMultiPackager(object):
     default_visual_runtimes = ["MT", "MD", "MTd", "MDd"]
     default_apple_clang_versions = ["7.3", "8.0", "8.1"]
     default_archs = ["x86", "x86_64"]
+    default_build_type = ["Release", "Debug"]
 
     def __init__(self, args=None, username=None, channel=None, runner=None,
                  gcc_versions=None, visual_versions=None, visual_runtimes=None,
@@ -81,7 +82,8 @@ class ConanMultiPackager(object):
                  upload_retry=None,
                  clang_versions=None,
                  login_username=None,
-                 upload_only_when_stable=False):
+                 upload_only_when_stable=False,
+                 build_type=None):
 
         self._builds = []
         self._named_builds = {}
@@ -164,6 +166,10 @@ class ConanMultiPackager(object):
         self.archs = archs or \
             list(filter(None, os.getenv("CONAN_ARCHS", "").split(","))) or \
             self.default_archs
+
+        self.build_type = build_type or \
+            list(filter(None, os.getenv("CONAN_BUILD_TYPE", "").split(","))) or \
+            self.default_build_type
 
         # If CONAN_DOCKER_IMAGE is speified, then use docker is True
         self.use_docker = use_docker or os.getenv("CONAN_USE_DOCKER", False) or (os.getenv("CONAN_DOCKER_IMAGE", None) is not None)
@@ -254,19 +260,20 @@ class ConanMultiPackager(object):
 
     def add_common_builds(self, shared_option_name=None, pure_c=True, dll_with_static_runtime=False):
         builds = []
+
         if self._platform_info.system() == "Windows":
             if self.mingw_configurations:
                 builds = get_mingw_builds(self.mingw_configurations, self.mingw_installer_reference, self.archs,
-                                            shared_option_name)
+                                            shared_option_name, self.build_type)
             builds.extend(get_visual_builds(self.visual_versions, self.archs, self.visual_runtimes,
-                                            shared_option_name, dll_with_static_runtime, self.vs10_x86_64_enabled))
+                                            shared_option_name, dll_with_static_runtime, self.vs10_x86_64_enabled, self.build_type))
         elif self._platform_info.system() == "Linux":
-            builds = get_linux_gcc_builds(self.gcc_versions, self.archs, shared_option_name, pure_c)
-            builds.extend(get_linux_clang_builds(self.clang_versions, self.archs, shared_option_name, pure_c))
+            builds = get_linux_gcc_builds(self.gcc_versions, self.archs, shared_option_name, pure_c, self.build_type)
+            builds.extend(get_linux_clang_builds(self.clang_versions, self.archs, shared_option_name, pure_c, self.build_type))
         elif self._platform_info.system() == "Darwin":
-            builds = get_osx_apple_clang_builds(self.apple_clang_versions, self.archs, shared_option_name, pure_c)
+            builds = get_osx_apple_clang_builds(self.apple_clang_versions, self.archs, shared_option_name, pure_c, self.build_type)
         elif self._platform_info.system() == "FreeBSD":
-            builds = get_linux_clang_builds(self.clang_versions, self.archs, shared_option_name, pure_c)
+            builds = get_linux_clang_builds(self.clang_versions, self.archs, shared_option_name, pure_c, self.build_type)
 
         self.builds.extend(builds)
 

--- a/conan/test/generators_test.py
+++ b/conan/test/generators_test.py
@@ -78,7 +78,7 @@ class GeneratorsTest(unittest.TestCase):
         self.assertEquals([tuple(a) for a in builds], expected)
 
     def test_get_osx_apple_clang_builds(self):
-        builds = get_osx_apple_clang_builds(["8.0"], ["x86_64"], "pack:shared", pure_c=False, build_type=["Debug", "Release"])
+        builds = get_osx_apple_clang_builds(["8.0"], ["x86_64"], "pack:shared", pure_c=False, build_types=["Debug", "Release"])
         expected = [({'arch': 'x86_64', 'compiler.libcxx': 'libc++', 'compiler': 'apple-clang', 'compiler.version': '8.0', 'build_type': 'Debug'},
                      {'pack:shared': True}, {}, {}),
                     ({'arch': 'x86_64', 'compiler.libcxx': 'libc++', 'compiler': 'apple-clang', 'compiler.version': '8.0', 'build_type': 'Release'},
@@ -89,7 +89,7 @@ class GeneratorsTest(unittest.TestCase):
                      {'pack:shared': False}, {}, {})]
         self.assertEquals([tuple(a) for a in builds], expected)
 
-        builds = get_osx_apple_clang_builds(["8.0"], ["x86_64"], "pack:shared", pure_c=True, build_type=["Debug", "Release"])
+        builds = get_osx_apple_clang_builds(["8.0"], ["x86_64"], "pack:shared", pure_c=True, build_types=["Debug", "Release"])
         expected = [({'arch': 'x86_64', 'compiler': 'apple-clang',
                       'compiler.version': '8.0', 'build_type': 'Debug'},
                      {'pack:shared': True}, {}, {}),
@@ -104,7 +104,7 @@ class GeneratorsTest(unittest.TestCase):
                      {'pack:shared': False}, {}, {})]
         self.assertEquals([tuple(a) for a in builds], expected)
 
-        builds = get_osx_apple_clang_builds(["8.0"], ["x86_64"], "pack:shared", pure_c=False, build_type=["Debug"])
+        builds = get_osx_apple_clang_builds(["8.0"], ["x86_64"], "pack:shared", pure_c=False, build_types=["Debug"])
         expected = [({'arch': 'x86_64', 'compiler.libcxx': 'libc++', 'compiler': 'apple-clang',
                       'compiler.version': '8.0', 'build_type': 'Debug'},
                      {'pack:shared': True}, {}, {}),
@@ -113,7 +113,7 @@ class GeneratorsTest(unittest.TestCase):
                      {'pack:shared': False}, {}, {})]
         self.assertEquals([tuple(a) for a in builds], expected)
 
-        builds = get_osx_apple_clang_builds(["8.0"], ["x86_64"], "pack:shared", pure_c=True, build_type=["Release"])
+        builds = get_osx_apple_clang_builds(["8.0"], ["x86_64"], "pack:shared", pure_c=True, build_types=["Release"])
         expected = [({'arch': 'x86_64', 'compiler': 'apple-clang',
                       'compiler.version': '8.0', 'build_type': 'Release'},
                      {'pack:shared': True}, {}, {}),
@@ -123,7 +123,7 @@ class GeneratorsTest(unittest.TestCase):
         self.assertEquals([tuple(a) for a in builds], expected)
 
     def test_get_linux_gcc_builds(self):
-        builds = get_linux_gcc_builds(["6.0"], ["x86_64"], "pack:shared", pure_c=False, build_type=["Debug", "Release"])
+        builds = get_linux_gcc_builds(["6.0"], ["x86_64"], "pack:shared", pure_c=False, build_types=["Debug", "Release"])
         expected = [({'compiler': 'gcc', 'build_type': 'Debug', 'compiler.libcxx': 'libstdc++', 'compiler.version': '6.0', 'arch': 'x86_64'},
                      {'pack:shared': True}, {}, {}),
                     ({'compiler': 'gcc', 'build_type': 'Debug', 'compiler.libcxx': 'libstdc++11', 'compiler.version': '6.0', 'arch': 'x86_64'},
@@ -142,7 +142,7 @@ class GeneratorsTest(unittest.TestCase):
                      {'pack:shared': False}, {}, {})]
         self.assertEquals([tuple(a) for a in builds], expected)
 
-        builds = get_linux_gcc_builds(["6.0"], ["x86_64"], "pack:shared", pure_c=True, build_type=["Debug", "Release"])
+        builds = get_linux_gcc_builds(["6.0"], ["x86_64"], "pack:shared", pure_c=True, build_types=["Debug", "Release"])
         expected = [({'arch': 'x86_64', 'compiler.version': '6.0', 'build_type': 'Debug', 'compiler': 'gcc'},
                      {'pack:shared': True}, {}, {}),
                     ({'arch': 'x86_64', 'compiler.version': '6.0', 'build_type': 'Release', 'compiler': 'gcc'},
@@ -153,7 +153,7 @@ class GeneratorsTest(unittest.TestCase):
                      {'pack:shared': False}, {}, {})]
         self.assertEquals([tuple(a) for a in builds], expected)
 
-        builds = get_linux_gcc_builds(["6.0"], ["x86_64"], "pack:shared", pure_c=False, build_type=["Debug"])
+        builds = get_linux_gcc_builds(["6.0"], ["x86_64"], "pack:shared", pure_c=False, build_types=["Debug"])
         expected = [({'compiler': 'gcc', 'build_type': 'Debug', 'compiler.libcxx': 'libstdc++',
                       'compiler.version': '6.0', 'arch': 'x86_64'},
                      {'pack:shared': True}, {}, {}),
@@ -168,14 +168,14 @@ class GeneratorsTest(unittest.TestCase):
                      {'pack:shared': False}, {}, {})]
         self.assertEquals([tuple(a) for a in builds], expected)
 
-        builds = get_linux_gcc_builds(["6.0"], ["x86_64"], "pack:shared", pure_c=True, build_type=["Debug"])
+        builds = get_linux_gcc_builds(["6.0"], ["x86_64"], "pack:shared", pure_c=True, build_types=["Debug"])
         expected = [({'arch': 'x86_64', 'compiler.version': '6.0', 'build_type': 'Debug', 'compiler': 'gcc'},
                      {'pack:shared': True}, {}, {}),
                     ({'arch': 'x86_64', 'compiler.version': '6.0', 'build_type': 'Debug', 'compiler': 'gcc'},
                      {'pack:shared': False}, {}, {})]
         self.assertEquals([tuple(a) for a in builds], expected)
 
-        builds = get_linux_gcc_builds(["6.0"], ["x86_64"], "pack:shared", pure_c=False, build_type=["Release"])
+        builds = get_linux_gcc_builds(["6.0"], ["x86_64"], "pack:shared", pure_c=False, build_types=["Release"])
         expected = [({'compiler': 'gcc', 'build_type': 'Release', 'compiler.libcxx': 'libstdc++',
                       'compiler.version': '6.0', 'arch': 'x86_64'},
                      {'pack:shared': True}, {}, {}),
@@ -190,7 +190,7 @@ class GeneratorsTest(unittest.TestCase):
                      {'pack:shared': False}, {}, {})]
         self.assertEquals([tuple(a) for a in builds], expected)
 
-        builds = get_linux_gcc_builds(["6.0"], ["x86_64"], "pack:shared", pure_c=True, build_type=["Release"])
+        builds = get_linux_gcc_builds(["6.0"], ["x86_64"], "pack:shared", pure_c=True, build_types=["Release"])
         expected = [({'arch': 'x86_64', 'compiler.version': '6.0', 'build_type': 'Release', 'compiler': 'gcc'},
                      {'pack:shared': True}, {}, {}),
                     ({'arch': 'x86_64', 'compiler.version': '6.0', 'build_type': 'Release', 'compiler': 'gcc'},
@@ -198,7 +198,7 @@ class GeneratorsTest(unittest.TestCase):
         self.assertEquals([tuple(a) for a in builds], expected)
 
     def test_get_linux_clang_builds(self):
-        builds = get_linux_clang_builds(["4.0"], ["x86_64"], "pack:shared", pure_c=False, build_type=["Debug", "Release"])
+        builds = get_linux_clang_builds(["4.0"], ["x86_64"], "pack:shared", pure_c=False, build_types=["Debug", "Release"])
         expected = [({'compiler': 'clang', 'build_type': 'Debug', 'compiler.libcxx': 'libstdc++', 'compiler.version': '4.0', 'arch': 'x86_64'},
                      {'pack:shared': True}, {}, {}),
                     ({'compiler': 'clang', 'build_type': 'Debug', 'compiler.libcxx': 'libc++', 'compiler.version': '4.0', 'arch': 'x86_64'},
@@ -217,7 +217,7 @@ class GeneratorsTest(unittest.TestCase):
                      {'pack:shared': False}, {}, {})]
         self.assertEquals([tuple(a) for a in builds], expected)
 
-        builds = get_linux_clang_builds(["4.0"], ["x86_64"], "pack:shared", pure_c=True, build_type=["Debug", "Release"])
+        builds = get_linux_clang_builds(["4.0"], ["x86_64"], "pack:shared", pure_c=True, build_types=["Debug", "Release"])
         expected = [({'arch': 'x86_64', 'compiler.version': '4.0', 'build_type': 'Debug', 'compiler': 'clang'},
                      {'pack:shared': True}, {}, {}),
                     ({'arch': 'x86_64', 'compiler.version': '4.0', 'build_type': 'Release', 'compiler': 'clang'},
@@ -228,7 +228,7 @@ class GeneratorsTest(unittest.TestCase):
                      {'pack:shared': False}, {}, {})]
         self.assertEquals([tuple(a) for a in builds], expected)
 
-        builds = get_linux_clang_builds(["4.0"], ["x86_64"], "pack:shared", pure_c=False, build_type=["Debug"])
+        builds = get_linux_clang_builds(["4.0"], ["x86_64"], "pack:shared", pure_c=False, build_types=["Debug"])
         expected = [({'compiler': 'clang', 'build_type': 'Debug', 'compiler.libcxx': 'libstdc++',
                       'compiler.version': '4.0', 'arch': 'x86_64'},
                      {'pack:shared': True}, {}, {}),
@@ -244,14 +244,14 @@ class GeneratorsTest(unittest.TestCase):
         self.assertEquals([tuple(a) for a in builds], expected)
 
         builds = get_linux_clang_builds(["4.0"], ["x86_64"], "pack:shared", pure_c=True,
-                                        build_type=["Debug"])
+                                        build_types=["Debug"])
         expected = [({'arch': 'x86_64', 'compiler.version': '4.0', 'build_type': 'Debug', 'compiler': 'clang'},
                      {'pack:shared': True}, {}, {}),
                     ({'arch': 'x86_64', 'compiler.version': '4.0', 'build_type': 'Debug', 'compiler': 'clang'},
                      {'pack:shared': False}, {}, {})]
         self.assertEquals([tuple(a) for a in builds], expected)
 
-        builds = get_linux_clang_builds(["4.0"], ["x86_64"], "pack:shared", pure_c=False, build_type=["Release"])
+        builds = get_linux_clang_builds(["4.0"], ["x86_64"], "pack:shared", pure_c=False, build_types=["Release"])
         expected = [({'compiler': 'clang', 'build_type': 'Release', 'compiler.libcxx': 'libstdc++',
                       'compiler.version': '4.0', 'arch': 'x86_64'},
                      {'pack:shared': True}, {}, {}),
@@ -268,8 +268,7 @@ class GeneratorsTest(unittest.TestCase):
                     {'pack:shared': False}, {}, {})]
         self.assertEquals([tuple(a) for a in builds], expected)
 
-        builds = get_linux_clang_builds(["4.0"], ["x86_64"], "pack:shared", pure_c=True,
-                                        build_type=["Release"])
+        builds = get_linux_clang_builds(["4.0"], ["x86_64"], "pack:shared", pure_c=True, build_types=["Release"])
         expected = [({'arch': 'x86_64', 'compiler.version': '4.0', 'build_type': 'Release', 'compiler': 'clang'},
                      {'pack:shared': True}, {}, {}),
                     ({'arch': 'x86_64', 'compiler.version': '4.0', 'build_type': 'Release', 'compiler': 'clang'},
@@ -281,7 +280,7 @@ class GeneratorsTest(unittest.TestCase):
                                    shared_option_name=None,
                                    dll_with_static_runtime=False,
                                    vs10_x86_64_enabled=True,
-                                   build_type=["Debug", "Release"])
+                                   build_types=["Debug", "Release"])
 
         expected = [
         ({'arch': 'x86', 'build_type': 'Debug', 'compiler': 'Visual Studio', 'compiler.version': '10', 'compiler.runtime': 'MTd'}, {}, {}, {}),
@@ -295,7 +294,7 @@ class GeneratorsTest(unittest.TestCase):
                                    shared_option_name="libpng:shared",
                                    dll_with_static_runtime=True,
                                    vs10_x86_64_enabled=True,
-                                   build_type=["Debug", "Release"])
+                                   build_types=["Debug", "Release"])
 
         expected = [
             ({'compiler.runtime': 'MDd', 'arch': 'x86', 'build_type': 'Debug', 'compiler': 'Visual Studio', 'compiler.version': '10'},
@@ -313,7 +312,7 @@ class GeneratorsTest(unittest.TestCase):
                                    shared_option_name="libpng:shared",
                                    dll_with_static_runtime=True,
                                    vs10_x86_64_enabled=False,
-                                   build_type=["Debug", "Release"])
+                                   build_types=["Debug", "Release"])
         expected = [
         ({'compiler.runtime': 'MDd', 'arch': 'x86', 'build_type': 'Debug', 'compiler': 'Visual Studio', 'compiler.version': '10'},
           {'libpng:shared': False}, {}, {}),
@@ -326,7 +325,7 @@ class GeneratorsTest(unittest.TestCase):
                                    shared_option_name="libpng:shared",
                                    dll_with_static_runtime=False,
                                    vs10_x86_64_enabled=False,
-                                   build_type=["Debug", "Release"])
+                                   build_types=["Debug", "Release"])
         expected = [
             ({'compiler': 'Visual Studio', 'compiler.runtime': 'MTd', 'compiler.version': '10', 'arch': 'x86', 'build_type': 'Debug'},
              {'libpng:shared': False}, {}, {})]
@@ -337,7 +336,7 @@ class GeneratorsTest(unittest.TestCase):
                                    shared_option_name=None,
                                    dll_with_static_runtime=False,
                                    vs10_x86_64_enabled=True,
-                                   build_type=["Debug"])
+                                   build_types=["Debug"])
 
         expected = [
             ({'arch': 'x86', 'build_type': 'Debug', 'compiler': 'Visual Studio', 'compiler.version': '10',
@@ -355,7 +354,7 @@ class GeneratorsTest(unittest.TestCase):
                                    shared_option_name="libpng:shared",
                                    dll_with_static_runtime=True,
                                    vs10_x86_64_enabled=True,
-                                   build_type=["Debug"])
+                                   build_types=["Debug"])
 
         expected = [
             ({'compiler.runtime': 'MDd', 'arch': 'x86', 'build_type': 'Debug', 'compiler': 'Visual Studio',
@@ -377,7 +376,7 @@ class GeneratorsTest(unittest.TestCase):
                                    shared_option_name="libpng:shared",
                                    dll_with_static_runtime=True,
                                    vs10_x86_64_enabled=False,
-                                   build_type=["Debug"])
+                                   build_types=["Debug"])
         expected = [
             ({'compiler.runtime': 'MDd', 'arch': 'x86', 'build_type': 'Debug', 'compiler': 'Visual Studio',
               'compiler.version': '10'},
@@ -392,7 +391,7 @@ class GeneratorsTest(unittest.TestCase):
                                    shared_option_name="libpng:shared",
                                    dll_with_static_runtime=False,
                                    vs10_x86_64_enabled=False,
-                                   build_type=["Debug"])
+                                   build_types=["Debug"])
         expected = [
             ({'compiler': 'Visual Studio', 'compiler.runtime': 'MTd', 'compiler.version': '10', 'arch': 'x86',
               'build_type': 'Debug'},
@@ -406,7 +405,7 @@ class GeneratorsTest(unittest.TestCase):
                                    shared_option_name=None,
                                    dll_with_static_runtime=False,
                                    vs10_x86_64_enabled=True,
-                                   build_type=["Release"])
+                                   build_types=["Release"])
 
         expected = [
             ({'arch': 'x86_64', 'build_type': 'Release', 'compiler': 'Visual Studio', 'compiler.version': '10',
@@ -424,7 +423,7 @@ class GeneratorsTest(unittest.TestCase):
                                    shared_option_name="libpng:shared",
                                    dll_with_static_runtime=True,
                                    vs10_x86_64_enabled=True,
-                                   build_type=["Release"])
+                                   build_types=["Release"])
 
         expected = [
             ({'compiler.runtime': 'MD', 'arch': 'x86', 'build_type': 'Release', 'compiler': 'Visual Studio',
@@ -446,7 +445,7 @@ class GeneratorsTest(unittest.TestCase):
                                    shared_option_name="libpng:shared",
                                    dll_with_static_runtime=True,
                                    vs10_x86_64_enabled=False,
-                                   build_type=["Release"])
+                                   build_types=["Release"])
         expected = [
             ({'compiler.runtime': 'MD', 'arch': 'x86', 'build_type': 'Release', 'compiler': 'Visual Studio',
               'compiler.version': '10'},
@@ -461,7 +460,7 @@ class GeneratorsTest(unittest.TestCase):
                                    shared_option_name="libpng:shared",
                                    dll_with_static_runtime=False,
                                    vs10_x86_64_enabled=False,
-                                   build_type=["Release"])
+                                   build_types=["Release"])
         expected = [
             ({'compiler': 'Visual Studio', 'compiler.runtime': 'MT', 'compiler.version': '10', 'arch': 'x86',
               'build_type': 'Release'},

--- a/conan/test/generators_test.py
+++ b/conan/test/generators_test.py
@@ -11,7 +11,7 @@ class GeneratorsTest(unittest.TestCase):
         mingw_configurations = [("4.9", "x86", "dwarf2", "posix")]
 
         builds = get_mingw_builds(mingw_configurations, ConanFileReference.loads(
-            "mingw_installer/1.0@conan/stable"), ["x86"], "pack:shared")
+            "mingw_installer/1.0@conan/stable"), ["x86"], "pack:shared", ["Release", "Debug"])
         expected = [
             ({'build_type': 'Release', 'compiler.version': '4.9', 'compiler.libcxx': "libstdc++",
               'compiler': 'gcc', 'arch': 'x86', 'compiler.exception': 'dwarf2',
@@ -41,8 +41,44 @@ class GeneratorsTest(unittest.TestCase):
 
         self.assertEquals([tuple(a) for a in builds], expected)
 
+        builds = get_mingw_builds(mingw_configurations, ConanFileReference.loads(
+            "mingw_installer/1.0@conan/stable"), ["x86"], "pack:shared", ["Release"])
+        expected = [
+            ({'build_type': 'Release', 'compiler.version': '4.9', 'compiler.libcxx': "libstdc++",
+              'compiler': 'gcc', 'arch': 'x86', 'compiler.exception': 'dwarf2',
+              'compiler.threads': 'posix'},
+             {'pack:shared': True},
+             {},
+             {'*': [ConanFileReference.loads("mingw_installer/1.0@conan/stable")]}),
+            ({'build_type': 'Release', 'compiler.version': '4.9', 'compiler.libcxx': "libstdc++",
+              'compiler': 'gcc', 'arch': 'x86', 'compiler.exception': 'dwarf2',
+              'compiler.threads': 'posix'},
+             {'pack:shared': False},
+             {},
+             {'*': [ConanFileReference.loads("mingw_installer/1.0@conan/stable")]})]
+
+        self.assertEquals([tuple(a) for a in builds], expected)
+
+        builds = get_mingw_builds(mingw_configurations, ConanFileReference.loads(
+            "mingw_installer/1.0@conan/stable"), ["x86"], "pack:shared", ["Debug"])
+        expected = [
+            ({'compiler.version': '4.9', 'compiler': 'gcc', 'compiler.libcxx': "libstdc++",
+              'build_type': 'Debug', 'compiler.exception': 'dwarf2', 'compiler.threads': 'posix',
+              'arch': 'x86'},
+             {'pack:shared': True},
+             {},
+             {'*': [ConanFileReference.loads("mingw_installer/1.0@conan/stable")]}),
+            ({'compiler.version': '4.9', 'compiler': 'gcc', 'compiler.libcxx': "libstdc++",
+              'build_type': 'Debug', 'compiler.exception': 'dwarf2', 'compiler.threads': 'posix',
+              'arch': 'x86'},
+             {'pack:shared': False},
+             {},
+             {'*': [ConanFileReference.loads("mingw_installer/1.0@conan/stable")]})]
+
+        self.assertEquals([tuple(a) for a in builds], expected)
+
     def test_get_osx_apple_clang_builds(self):
-        builds = get_osx_apple_clang_builds(["8.0"], ["x86_64"], "pack:shared", pure_c=False)
+        builds = get_osx_apple_clang_builds(["8.0"], ["x86_64"], "pack:shared", pure_c=False, build_type=["Debug", "Release"])
         expected = [({'arch': 'x86_64', 'compiler.libcxx': 'libc++', 'compiler': 'apple-clang', 'compiler.version': '8.0', 'build_type': 'Debug'},
                      {'pack:shared': True}, {}, {}),
                     ({'arch': 'x86_64', 'compiler.libcxx': 'libc++', 'compiler': 'apple-clang', 'compiler.version': '8.0', 'build_type': 'Release'},
@@ -50,11 +86,10 @@ class GeneratorsTest(unittest.TestCase):
                     ({'arch': 'x86_64', 'compiler.libcxx': 'libc++', 'compiler': 'apple-clang', 'compiler.version': '8.0', 'build_type': 'Debug'},
                      {'pack:shared': False}, {}, {}),
                     ({'arch': 'x86_64', 'compiler.libcxx': 'libc++', 'compiler': 'apple-clang', 'compiler.version': '8.0', 'build_type': 'Release'},
-                     {'pack:shared': False}, {}, {}),
-                   ]
+                     {'pack:shared': False}, {}, {})]
         self.assertEquals([tuple(a) for a in builds], expected)
 
-        builds = get_osx_apple_clang_builds(["8.0"], ["x86_64"], "pack:shared", pure_c=True)
+        builds = get_osx_apple_clang_builds(["8.0"], ["x86_64"], "pack:shared", pure_c=True, build_type=["Debug", "Release"])
         expected = [({'arch': 'x86_64', 'compiler': 'apple-clang',
                       'compiler.version': '8.0', 'build_type': 'Debug'},
                      {'pack:shared': True}, {}, {}),
@@ -66,12 +101,29 @@ class GeneratorsTest(unittest.TestCase):
                      {'pack:shared': False}, {}, {}),
                     ({'arch': 'x86_64', 'compiler': 'apple-clang',
                       'compiler.version': '8.0', 'build_type': 'Release'},
-                     {'pack:shared': False}, {}, {}),
-                    ]
+                     {'pack:shared': False}, {}, {})]
+        self.assertEquals([tuple(a) for a in builds], expected)
+
+        builds = get_osx_apple_clang_builds(["8.0"], ["x86_64"], "pack:shared", pure_c=False, build_type=["Debug"])
+        expected = [({'arch': 'x86_64', 'compiler.libcxx': 'libc++', 'compiler': 'apple-clang',
+                      'compiler.version': '8.0', 'build_type': 'Debug'},
+                     {'pack:shared': True}, {}, {}),
+                    ({'arch': 'x86_64', 'compiler.libcxx': 'libc++', 'compiler': 'apple-clang',
+                      'compiler.version': '8.0', 'build_type': 'Debug'},
+                     {'pack:shared': False}, {}, {})]
+        self.assertEquals([tuple(a) for a in builds], expected)
+
+        builds = get_osx_apple_clang_builds(["8.0"], ["x86_64"], "pack:shared", pure_c=True, build_type=["Release"])
+        expected = [({'arch': 'x86_64', 'compiler': 'apple-clang',
+                      'compiler.version': '8.0', 'build_type': 'Release'},
+                     {'pack:shared': True}, {}, {}),
+                    ({'arch': 'x86_64', 'compiler': 'apple-clang',
+                      'compiler.version': '8.0', 'build_type': 'Release'},
+                     {'pack:shared': False}, {}, {})]
         self.assertEquals([tuple(a) for a in builds], expected)
 
     def test_get_linux_gcc_builds(self):
-        builds = get_linux_gcc_builds(["6.0"], ["x86_64"], "pack:shared", pure_c=False)
+        builds = get_linux_gcc_builds(["6.0"], ["x86_64"], "pack:shared", pure_c=False, build_type=["Debug", "Release"])
         expected = [({'compiler': 'gcc', 'build_type': 'Debug', 'compiler.libcxx': 'libstdc++', 'compiler.version': '6.0', 'arch': 'x86_64'},
                      {'pack:shared': True}, {}, {}),
                     ({'compiler': 'gcc', 'build_type': 'Debug', 'compiler.libcxx': 'libstdc++11', 'compiler.version': '6.0', 'arch': 'x86_64'},
@@ -90,7 +142,7 @@ class GeneratorsTest(unittest.TestCase):
                      {'pack:shared': False}, {}, {})]
         self.assertEquals([tuple(a) for a in builds], expected)
 
-        builds = get_linux_gcc_builds(["6.0"], ["x86_64"], "pack:shared", pure_c=True)
+        builds = get_linux_gcc_builds(["6.0"], ["x86_64"], "pack:shared", pure_c=True, build_type=["Debug", "Release"])
         expected = [({'arch': 'x86_64', 'compiler.version': '6.0', 'build_type': 'Debug', 'compiler': 'gcc'},
                      {'pack:shared': True}, {}, {}),
                     ({'arch': 'x86_64', 'compiler.version': '6.0', 'build_type': 'Release', 'compiler': 'gcc'},
@@ -101,8 +153,52 @@ class GeneratorsTest(unittest.TestCase):
                      {'pack:shared': False}, {}, {})]
         self.assertEquals([tuple(a) for a in builds], expected)
 
+        builds = get_linux_gcc_builds(["6.0"], ["x86_64"], "pack:shared", pure_c=False, build_type=["Debug"])
+        expected = [({'compiler': 'gcc', 'build_type': 'Debug', 'compiler.libcxx': 'libstdc++',
+                      'compiler.version': '6.0', 'arch': 'x86_64'},
+                     {'pack:shared': True}, {}, {}),
+                    ({'compiler': 'gcc', 'build_type': 'Debug', 'compiler.libcxx': 'libstdc++11',
+                      'compiler.version': '6.0', 'arch': 'x86_64'},
+                     {'pack:shared': True}, {}, {}),
+                    ({'compiler': 'gcc', 'build_type': 'Debug', 'compiler.libcxx': 'libstdc++',
+                      'compiler.version': '6.0', 'arch': 'x86_64'},
+                     {'pack:shared': False}, {}, {}),
+                    ({'compiler': 'gcc', 'build_type': 'Debug', 'compiler.libcxx': 'libstdc++11',
+                      'compiler.version': '6.0', 'arch': 'x86_64'},
+                     {'pack:shared': False}, {}, {})]
+        self.assertEquals([tuple(a) for a in builds], expected)
+
+        builds = get_linux_gcc_builds(["6.0"], ["x86_64"], "pack:shared", pure_c=True, build_type=["Debug"])
+        expected = [({'arch': 'x86_64', 'compiler.version': '6.0', 'build_type': 'Debug', 'compiler': 'gcc'},
+                     {'pack:shared': True}, {}, {}),
+                    ({'arch': 'x86_64', 'compiler.version': '6.0', 'build_type': 'Debug', 'compiler': 'gcc'},
+                     {'pack:shared': False}, {}, {})]
+        self.assertEquals([tuple(a) for a in builds], expected)
+
+        builds = get_linux_gcc_builds(["6.0"], ["x86_64"], "pack:shared", pure_c=False, build_type=["Release"])
+        expected = [({'compiler': 'gcc', 'build_type': 'Release', 'compiler.libcxx': 'libstdc++',
+                      'compiler.version': '6.0', 'arch': 'x86_64'},
+                     {'pack:shared': True}, {}, {}),
+                    ({'compiler': 'gcc', 'build_type': 'Release', 'compiler.libcxx': 'libstdc++11',
+                      'compiler.version': '6.0', 'arch': 'x86_64'},
+                     {'pack:shared': True}, {}, {}),
+                    ({'compiler': 'gcc', 'build_type': 'Release', 'compiler.libcxx': 'libstdc++',
+                      'compiler.version': '6.0', 'arch': 'x86_64'},
+                     {'pack:shared': False}, {}, {}),
+                    ({'compiler': 'gcc', 'build_type': 'Release', 'compiler.libcxx': 'libstdc++11',
+                      'compiler.version': '6.0', 'arch': 'x86_64'},
+                     {'pack:shared': False}, {}, {})]
+        self.assertEquals([tuple(a) for a in builds], expected)
+
+        builds = get_linux_gcc_builds(["6.0"], ["x86_64"], "pack:shared", pure_c=True, build_type=["Release"])
+        expected = [({'arch': 'x86_64', 'compiler.version': '6.0', 'build_type': 'Release', 'compiler': 'gcc'},
+                     {'pack:shared': True}, {}, {}),
+                    ({'arch': 'x86_64', 'compiler.version': '6.0', 'build_type': 'Release', 'compiler': 'gcc'},
+                     {'pack:shared': False}, {}, {})]
+        self.assertEquals([tuple(a) for a in builds], expected)
+
     def test_get_linux_clang_builds(self):
-        builds = get_linux_clang_builds(["4.0"], ["x86_64"], "pack:shared", pure_c=False)
+        builds = get_linux_clang_builds(["4.0"], ["x86_64"], "pack:shared", pure_c=False, build_type=["Debug", "Release"])
         expected = [({'compiler': 'clang', 'build_type': 'Debug', 'compiler.libcxx': 'libstdc++', 'compiler.version': '4.0', 'arch': 'x86_64'},
                      {'pack:shared': True}, {}, {}),
                     ({'compiler': 'clang', 'build_type': 'Debug', 'compiler.libcxx': 'libc++', 'compiler.version': '4.0', 'arch': 'x86_64'},
@@ -121,7 +217,7 @@ class GeneratorsTest(unittest.TestCase):
                      {'pack:shared': False}, {}, {})]
         self.assertEquals([tuple(a) for a in builds], expected)
 
-        builds = get_linux_clang_builds(["4.0"], ["x86_64"], "pack:shared", pure_c=True)
+        builds = get_linux_clang_builds(["4.0"], ["x86_64"], "pack:shared", pure_c=True, build_type=["Debug", "Release"])
         expected = [({'arch': 'x86_64', 'compiler.version': '4.0', 'build_type': 'Debug', 'compiler': 'clang'},
                      {'pack:shared': True}, {}, {}),
                     ({'arch': 'x86_64', 'compiler.version': '4.0', 'build_type': 'Release', 'compiler': 'clang'},
@@ -132,11 +228,60 @@ class GeneratorsTest(unittest.TestCase):
                      {'pack:shared': False}, {}, {})]
         self.assertEquals([tuple(a) for a in builds], expected)
 
+        builds = get_linux_clang_builds(["4.0"], ["x86_64"], "pack:shared", pure_c=False, build_type=["Debug"])
+        expected = [({'compiler': 'clang', 'build_type': 'Debug', 'compiler.libcxx': 'libstdc++',
+                      'compiler.version': '4.0', 'arch': 'x86_64'},
+                     {'pack:shared': True}, {}, {}),
+                    ({'compiler': 'clang', 'build_type': 'Debug', 'compiler.libcxx': 'libc++', 'compiler.version': '4.0',
+                     'arch': 'x86_64'},
+                    {'pack:shared': True}, {}, {}),
+                    ({'compiler': 'clang', 'build_type': 'Debug', 'compiler.libcxx': 'libstdc++',
+                      'compiler.version': '4.0', 'arch': 'x86_64'},
+                     {'pack:shared': False}, {}, {}),
+                    ({'compiler': 'clang', 'build_type': 'Debug', 'compiler.libcxx': 'libc++', 'compiler.version': '4.0',
+                     'arch': 'x86_64'},
+                    {'pack:shared': False}, {}, {})]
+        self.assertEquals([tuple(a) for a in builds], expected)
+
+        builds = get_linux_clang_builds(["4.0"], ["x86_64"], "pack:shared", pure_c=True,
+                                        build_type=["Debug"])
+        expected = [({'arch': 'x86_64', 'compiler.version': '4.0', 'build_type': 'Debug', 'compiler': 'clang'},
+                     {'pack:shared': True}, {}, {}),
+                    ({'arch': 'x86_64', 'compiler.version': '4.0', 'build_type': 'Debug', 'compiler': 'clang'},
+                     {'pack:shared': False}, {}, {})]
+        self.assertEquals([tuple(a) for a in builds], expected)
+
+        builds = get_linux_clang_builds(["4.0"], ["x86_64"], "pack:shared", pure_c=False, build_type=["Release"])
+        expected = [({'compiler': 'clang', 'build_type': 'Release', 'compiler.libcxx': 'libstdc++',
+                      'compiler.version': '4.0', 'arch': 'x86_64'},
+                     {'pack:shared': True}, {}, {}),
+                    (
+                    {'compiler': 'clang', 'build_type': 'Release', 'compiler.libcxx': 'libc++', 'compiler.version': '4.0',
+                     'arch': 'x86_64'},
+                    {'pack:shared': True}, {}, {}),
+                    ({'compiler': 'clang', 'build_type': 'Release', 'compiler.libcxx': 'libstdc++',
+                      'compiler.version': '4.0', 'arch': 'x86_64'},
+                     {'pack:shared': False}, {}, {}),
+                    (
+                    {'compiler': 'clang', 'build_type': 'Release', 'compiler.libcxx': 'libc++', 'compiler.version': '4.0',
+                     'arch': 'x86_64'},
+                    {'pack:shared': False}, {}, {})]
+        self.assertEquals([tuple(a) for a in builds], expected)
+
+        builds = get_linux_clang_builds(["4.0"], ["x86_64"], "pack:shared", pure_c=True,
+                                        build_type=["Release"])
+        expected = [({'arch': 'x86_64', 'compiler.version': '4.0', 'build_type': 'Release', 'compiler': 'clang'},
+                     {'pack:shared': True}, {}, {}),
+                    ({'arch': 'x86_64', 'compiler.version': '4.0', 'build_type': 'Release', 'compiler': 'clang'},
+                     {'pack:shared': False}, {}, {})]
+        self.assertEquals([tuple(a) for a in builds], expected)
+
     def test_visual_build_generator(self):
         builds = get_visual_builds(visual_versions=["10", "14"], archs=["x86"], visual_runtimes=["MDd", "MTd"],
                                    shared_option_name=None,
                                    dll_with_static_runtime=False,
-                                   vs10_x86_64_enabled=True)
+                                   vs10_x86_64_enabled=True,
+                                   build_type=["Debug", "Release"])
 
         expected = [
         ({'arch': 'x86', 'build_type': 'Debug', 'compiler': 'Visual Studio', 'compiler.version': '10', 'compiler.runtime': 'MTd'}, {}, {}, {}),
@@ -149,7 +294,8 @@ class GeneratorsTest(unittest.TestCase):
         builds = get_visual_builds(visual_versions=["10"], archs=["x86", "x86_64"], visual_runtimes=["MDd"],
                                    shared_option_name="libpng:shared",
                                    dll_with_static_runtime=True,
-                                   vs10_x86_64_enabled=True)
+                                   vs10_x86_64_enabled=True,
+                                   build_type=["Debug", "Release"])
 
         expected = [
             ({'compiler.runtime': 'MDd', 'arch': 'x86', 'build_type': 'Debug', 'compiler': 'Visual Studio', 'compiler.version': '10'},
@@ -166,7 +312,8 @@ class GeneratorsTest(unittest.TestCase):
         builds = get_visual_builds(visual_versions=["10"], archs=["x86", "x86_64"], visual_runtimes=["MDd"],
                                    shared_option_name="libpng:shared",
                                    dll_with_static_runtime=True,
-                                   vs10_x86_64_enabled=False)
+                                   vs10_x86_64_enabled=False,
+                                   build_type=["Debug", "Release"])
         expected = [
         ({'compiler.runtime': 'MDd', 'arch': 'x86', 'build_type': 'Debug', 'compiler': 'Visual Studio', 'compiler.version': '10'},
           {'libpng:shared': False}, {}, {}),
@@ -178,9 +325,146 @@ class GeneratorsTest(unittest.TestCase):
         builds = get_visual_builds(visual_versions=["10"], archs=["x86", "x86_64"], visual_runtimes=["MTd"],
                                    shared_option_name="libpng:shared",
                                    dll_with_static_runtime=False,
-                                   vs10_x86_64_enabled=False)
+                                   vs10_x86_64_enabled=False,
+                                   build_type=["Debug", "Release"])
         expected = [
             ({'compiler': 'Visual Studio', 'compiler.runtime': 'MTd', 'compiler.version': '10', 'arch': 'x86', 'build_type': 'Debug'},
+             {'libpng:shared': False}, {}, {})]
+
+        self.assertEquals([tuple(a) for a in builds], expected)
+
+        builds = get_visual_builds(visual_versions=["10", "14"], archs=["x86"], visual_runtimes=["MDd", "MTd"],
+                                   shared_option_name=None,
+                                   dll_with_static_runtime=False,
+                                   vs10_x86_64_enabled=True,
+                                   build_type=["Debug"])
+
+        expected = [
+            ({'arch': 'x86', 'build_type': 'Debug', 'compiler': 'Visual Studio', 'compiler.version': '10',
+              'compiler.runtime': 'MTd'}, {}, {}, {}),
+            ({'arch': 'x86', 'build_type': 'Debug', 'compiler': 'Visual Studio', 'compiler.version': '10',
+              'compiler.runtime': 'MDd'}, {}, {}, {}),
+            ({'arch': 'x86', 'build_type': 'Debug', 'compiler': 'Visual Studio', 'compiler.version': '14',
+              'compiler.runtime': 'MTd'}, {}, {}, {}),
+            ({'arch': 'x86', 'build_type': 'Debug', 'compiler': 'Visual Studio', 'compiler.version': '14',
+              'compiler.runtime': 'MDd'}, {}, {}, {})]
+
+        self.assertEquals([tuple(a) for a in builds], expected)
+
+        builds = get_visual_builds(visual_versions=["10"], archs=["x86", "x86_64"], visual_runtimes=["MDd"],
+                                   shared_option_name="libpng:shared",
+                                   dll_with_static_runtime=True,
+                                   vs10_x86_64_enabled=True,
+                                   build_type=["Debug"])
+
+        expected = [
+            ({'compiler.runtime': 'MDd', 'arch': 'x86', 'build_type': 'Debug', 'compiler': 'Visual Studio',
+              'compiler.version': '10'},
+             {'libpng:shared': False}, {}, {}),
+            ({'compiler.runtime': 'MDd', 'arch': 'x86', 'build_type': 'Debug', 'compiler': 'Visual Studio',
+              'compiler.version': '10'},
+             {'libpng:shared': True}, {}, {}),
+            ({'compiler.runtime': 'MDd', 'arch': 'x86_64', 'build_type': 'Debug', 'compiler': 'Visual Studio',
+              'compiler.version': '10'},
+             {'libpng:shared': False}, {}, {}),
+            ({'compiler.runtime': 'MDd', 'arch': 'x86_64', 'build_type': 'Debug', 'compiler': 'Visual Studio',
+              'compiler.version': '10'},
+             {'libpng:shared': True}, {}, {})]
+
+        self.assertEquals([tuple(a) for a in builds], expected)
+
+        builds = get_visual_builds(visual_versions=["10"], archs=["x86", "x86_64"], visual_runtimes=["MDd"],
+                                   shared_option_name="libpng:shared",
+                                   dll_with_static_runtime=True,
+                                   vs10_x86_64_enabled=False,
+                                   build_type=["Debug"])
+        expected = [
+            ({'compiler.runtime': 'MDd', 'arch': 'x86', 'build_type': 'Debug', 'compiler': 'Visual Studio',
+              'compiler.version': '10'},
+             {'libpng:shared': False}, {}, {}),
+            ({'compiler.runtime': 'MDd', 'arch': 'x86', 'build_type': 'Debug', 'compiler': 'Visual Studio',
+              'compiler.version': '10'},
+             {'libpng:shared': True}, {}, {})]
+
+        self.assertEquals([tuple(a) for a in builds], expected)
+
+        builds = get_visual_builds(visual_versions=["10"], archs=["x86", "x86_64"], visual_runtimes=["MTd"],
+                                   shared_option_name="libpng:shared",
+                                   dll_with_static_runtime=False,
+                                   vs10_x86_64_enabled=False,
+                                   build_type=["Debug"])
+        expected = [
+            ({'compiler': 'Visual Studio', 'compiler.runtime': 'MTd', 'compiler.version': '10', 'arch': 'x86',
+              'build_type': 'Debug'},
+             {'libpng:shared': False}, {}, {})]
+
+        self.assertEquals([tuple(a) for a in builds], expected)
+
+        #############
+
+        builds = get_visual_builds(visual_versions=["10", "14"], archs=["x86_64"], visual_runtimes=["MD", "MT"],
+                                   shared_option_name=None,
+                                   dll_with_static_runtime=False,
+                                   vs10_x86_64_enabled=True,
+                                   build_type=["Release"])
+
+        expected = [
+            ({'arch': 'x86_64', 'build_type': 'Release', 'compiler': 'Visual Studio', 'compiler.version': '10',
+              'compiler.runtime': 'MT'}, {}, {}, {}),
+            ({'arch': 'x86_64', 'build_type': 'Release', 'compiler': 'Visual Studio', 'compiler.version': '10',
+              'compiler.runtime': 'MD'}, {}, {}, {}),
+            ({'arch': 'x86_64', 'build_type': 'Release', 'compiler': 'Visual Studio', 'compiler.version': '14',
+              'compiler.runtime': 'MT'}, {}, {}, {}),
+            ({'arch': 'x86_64', 'build_type': 'Release', 'compiler': 'Visual Studio', 'compiler.version': '14',
+              'compiler.runtime': 'MD'}, {}, {}, {})]
+
+        self.assertEquals([tuple(a) for a in builds], expected)
+
+        builds = get_visual_builds(visual_versions=["10"], archs=["x86", "x86_64"], visual_runtimes=["MD"],
+                                   shared_option_name="libpng:shared",
+                                   dll_with_static_runtime=True,
+                                   vs10_x86_64_enabled=True,
+                                   build_type=["Release"])
+
+        expected = [
+            ({'compiler.runtime': 'MD', 'arch': 'x86', 'build_type': 'Release', 'compiler': 'Visual Studio',
+              'compiler.version': '10'},
+             {'libpng:shared': False}, {}, {}),
+            ({'compiler.runtime': 'MD', 'arch': 'x86', 'build_type': 'Release', 'compiler': 'Visual Studio',
+              'compiler.version': '10'},
+             {'libpng:shared': True}, {}, {}),
+            ({'compiler.runtime': 'MD', 'arch': 'x86_64', 'build_type': 'Release', 'compiler': 'Visual Studio',
+              'compiler.version': '10'},
+             {'libpng:shared': False}, {}, {}),
+            ({'compiler.runtime': 'MD', 'arch': 'x86_64', 'build_type': 'Release', 'compiler': 'Visual Studio',
+              'compiler.version': '10'},
+             {'libpng:shared': True}, {}, {})]
+
+        self.assertEquals([tuple(a) for a in builds], expected)
+
+        builds = get_visual_builds(visual_versions=["10"], archs=["x86", "x86_64"], visual_runtimes=["MD"],
+                                   shared_option_name="libpng:shared",
+                                   dll_with_static_runtime=True,
+                                   vs10_x86_64_enabled=False,
+                                   build_type=["Release"])
+        expected = [
+            ({'compiler.runtime': 'MD', 'arch': 'x86', 'build_type': 'Release', 'compiler': 'Visual Studio',
+              'compiler.version': '10'},
+             {'libpng:shared': False}, {}, {}),
+            ({'compiler.runtime': 'MD', 'arch': 'x86', 'build_type': 'Release', 'compiler': 'Visual Studio',
+              'compiler.version': '10'},
+             {'libpng:shared': True}, {}, {})]
+
+        self.assertEquals([tuple(a) for a in builds], expected)
+
+        builds = get_visual_builds(visual_versions=["10"], archs=["x86", "x86_64"], visual_runtimes=["MT"],
+                                   shared_option_name="libpng:shared",
+                                   dll_with_static_runtime=False,
+                                   vs10_x86_64_enabled=False,
+                                   build_type=["Release"])
+        expected = [
+            ({'compiler': 'Visual Studio', 'compiler.runtime': 'MT', 'compiler.version': '10', 'arch': 'x86',
+              'build_type': 'Release'},
              {'libpng:shared': False}, {}, {})]
 
         self.assertEquals([tuple(a) for a in builds], expected)


### PR DESCRIPTION
Hi!

As described at issue #105, I bring a solution to filter the build configuration when `ConanMultiPackager` is created.

Also, I added new tests to make sure that this feature won't break the previous configuration.

Saludos!