### PR TITLE
Log info messages to stdout instead of stderr 

### DIFF
--- a/conan/log.py
+++ b/conan/log.py
@@ -29,7 +29,7 @@ logger = logging.getLogger('conans')
 if CONAN_LOGGING_FILE is not None:
     hdlr = logging.FileHandler(CONAN_LOGGING_FILE)
 else:
-    hdlr = StreamHandler(sys.stderr)
+    hdlr = StreamHandler(sys.stdout)
 
 formatter = MultiLineFormatter('\n############## CONAN PACKAGE TOOLS ######################\n\n%(levelname)s: '
                                '%(message)s \n\n#########################################################\n')


### PR DESCRIPTION
so that actual errors are more visible