### PR TITLE
Added exclude_precommand parameter.

### DIFF
--- a/conan/packager.py
+++ b/conan/packager.py
@@ -91,7 +91,8 @@ class ConanMultiPackager(object):
                  upload_only_when_stable=False,
                  build_types=None,
                  skip_check_credentials=False,
-                 allow_gcc_minors=False):
+                 allow_gcc_minors=False,
+                 exclude_precommand=False):
 
         self.sudo_command = ""
         if "CONAN_DOCKER_USE_SUDO" in os.environ:
@@ -100,6 +101,7 @@ class ConanMultiPackager(object):
         elif platform.system() == "Linux":
             self.sudo_command = "sudo"
 
+        self.exclude_precommand = exclude_precommand
         self.allow_gcc_minors = allow_gcc_minors or os.getenv("CONAN_ALLOW_GCC_MINORS", False)
         self._builds = []
         self._named_builds = {}
@@ -436,7 +438,8 @@ won't be able to use them.
                                                  build.reference,
                                                  self.mingw_installer_reference, self.runner,
                                                  self.args,
-                                                 conan_pip_package=self.conan_pip_package)
+                                                 conan_pip_package=self.conan_pip_package,
+                                                 exclude_precommand=self.exclude_precommand)
                 build_runner.run()
 
     def login(self, remote_name, user=None, password=None, force=False):

--- a/conan/test/packager_test.py
+++ b/conan/test/packager_test.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import unittest
 
 from collections import defaultdict
@@ -203,6 +204,7 @@ class AppTest(unittest.TestCase):
         self.assertIn('os=os4', self.runner.calls[20])
         self.assertIn('os=os6', self.runner.calls[21])
 
+    @unittest.skipUnless(sys.platform.startswith("win"), "Requires Windows")
     def test_msvc(self):
         self.packager = ConanMultiPackager("--build missing -r conan.io",
                                            "lasote", "mychannel",
@@ -210,10 +212,11 @@ class AppTest(unittest.TestCase):
                                            visual_versions=[15])
         self.packager.add_common_builds()                                           
         self.packager.run()
-
+        
         self.assertIn("vcvarsall.bat", self.runner.calls[1])
         self.assertIn("vcvarsall.bat", self.runner.calls[2])
 
+    @unittest.skipUnless(sys.platform.startswith("win"), "Requires Windows")
     def test_msvc_no_precommand(self):
         self.packager = ConanMultiPackager("--build missing -r conan.io",
                                            "lasote", "mychannel",

--- a/conan/test/packager_test.py
+++ b/conan/test/packager_test.py
@@ -210,11 +210,12 @@ class AppTest(unittest.TestCase):
                                            "lasote", "mychannel",
                                            runner=self.runner,
                                            visual_versions=[15])
-        self.packager.add_common_builds()                                           
-        self.packager.run()
+        self.packager.add_common_builds()      
+
+        with tools.environment_append({"VisualStudioVersion": "15.0"}):
+            self.packager.run_builds(1, 1)
         
-        self.assertIn("vcvarsall.bat", self.runner.calls[1])
-        self.assertIn("vcvarsall.bat", self.runner.calls[2])
+        self.assertIn("vcvars", self.runner.calls[1])
 
     @unittest.skipUnless(sys.platform.startswith("win"), "Requires Windows")
     def test_msvc_no_precommand(self):
@@ -224,10 +225,9 @@ class AppTest(unittest.TestCase):
                                            visual_versions=[15],
                                            exclude_precommand=True)
         self.packager.add_common_builds()                                           
-        self.packager.run()
+        self.packager.run_builds(1, 1)
 
-        self.assertNotIn("vcvarsall.bat", self.runner.calls[1])
-        self.assertNotIn("vcvarsall.bat", self.runner.calls[2])
+        self.assertNotIn("vcvars", self.runner.calls[1])
 
     def test_docker_invalid(self):
         self.packager = ConanMultiPackager("--build missing -r conan.io",

--- a/conan/test/packager_test.py
+++ b/conan/test/packager_test.py
@@ -203,6 +203,29 @@ class AppTest(unittest.TestCase):
         self.assertIn('os=os4', self.runner.calls[20])
         self.assertIn('os=os6', self.runner.calls[21])
 
+    def test_msvc(self):
+        self.packager = ConanMultiPackager("--build missing -r conan.io",
+                                           "lasote", "mychannel",
+                                           runner=self.runner,
+                                           visual_versions=[15])
+        self.packager.add_common_builds()                                           
+        self.packager.run()
+
+        self.assertIn("vcvarsall.bat", self.runner.calls[1])
+        self.assertIn("vcvarsall.bat", self.runner.calls[2])
+
+    def test_msvc_no_precommand(self):
+        self.packager = ConanMultiPackager("--build missing -r conan.io",
+                                           "lasote", "mychannel",
+                                           runner=self.runner,
+                                           visual_versions=[15],
+                                           exclude_precommand=True)
+        self.packager.add_common_builds()                                           
+        self.packager.run()
+
+        self.assertNotIn("vcvarsall.bat", self.runner.calls[1])
+        self.assertNotIn("vcvarsall.bat", self.runner.calls[2])
+
     def test_docker_invalid(self):
         self.packager = ConanMultiPackager("--build missing -r conan.io",
                                            "lasote", "mychannel",


### PR DESCRIPTION
This change allows us to exclude the `pre_command` behavior in the `run()` method.

Ultimately, we are attempting to use a build agent that has MS build tools installed but not visual studio. This requires us to call `vcvarsall.bat` in a slightly different way from the default which is handled in the relevant Conan recipes called when the `run()` method executes the `conan create ...` process.

Note, I understand that it is possible to get the same functionality using a custom runner that truncates the vcvarsall.bat call in the generated command line but this change seems cleaner. 