### PR TITLE
add env var to skip initialisation update to the docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -888,6 +888,7 @@ This is especially useful for CI integration.
 - **CONAN_CURRENT_PAGE**:  Current page of packages to create
 - **CONAN_TOTAL_PAGES**: Total number of pages
 - **CONAN_DOCKER_IMAGE**: If defined and docker is being used, it will use this dockerimage instead of the default images, e.g. "lasote/conangcc63"
+- **CONAN_DOCKER_IMAGE_SKIP_UPDATE**: If defined, it will skip the initialisation update of "conan package tools" and "conan" in the docker image. By default is False.
 - **CONAN_STABLE_BRANCH_PATTERN**: Regular expression, if current git branch matches this pattern, the packages will be uploaded to *CONAN_STABLE_CHANNEL* channel. Default "master". E.j: "release/*"
 - **CONAN_STABLE_CHANNEL**: Stable channel name, default "stable"
 - **CONAN_STABLE_USERNAME**: Your conan username in case the `CONAN_STABLE_BRANCH_PATTERN` matches. Optional. If not defined `CONAN_USERNAME` is used.

--- a/conan/create_runner.py
+++ b/conan/create_runner.py
@@ -128,20 +128,21 @@ class DockerTestPackageRunner(TestPackageRunner):
 
         if pull_image:
             self.pull_image()
-            # Update the downloaded image
-            command = "%s docker run --name conan_runner %s /bin/sh -c " \
-                      "\"sudo pip install conan_package_tools==%s " \
-                      "--upgrade" % (self.sudo_command, self.docker_image, package_tools_version)
-            if self._conan_pip_package:
-                command += " && sudo pip install %s\"" % self._conan_pip_package
-            else:
-                command += " && sudo pip install conan --upgrade\""
+            if not os.getenv("CONAN_DOCKER_IMAGE_SKIP_UPDATE", False):
+                # Update the downloaded image
+                command = "%s docker run --name conan_runner %s /bin/sh -c " \
+                        "\"sudo pip install conan_package_tools==%s " \
+                        "--upgrade" % (self.sudo_command, self.docker_image, package_tools_version)
+                if self._conan_pip_package:
+                    command += " && sudo pip install %s\"" % self._conan_pip_package
+                else:
+                    command += " && sudo pip install conan --upgrade\""
 
-            self._runner(command)
-            # Save the image with the updated installed
-            # packages and remove the intermediate container
-            self._runner("%s docker commit conan_runner %s" % (self.sudo_command, self.docker_image))
-            self._runner("%s docker rm conan_runner" % self.sudo_command)
+                self._runner(command)
+                # Save the image with the updated installed
+                # packages and remove the intermediate container
+                self._runner("%s docker commit conan_runner %s" % (self.sudo_command, self.docker_image))
+                self._runner("%s docker rm conan_runner" % self.sudo_command)
 
         # Run the build
         serial = pipes.quote(self.serialize())


### PR DESCRIPTION
Fix for #139 
Allow users to skip the initialisation update step on the used docker image.
Necessary if a server runs multiple jobs with the same docker image and the user already provides a docker images with the newest versions