### PR TITLE
Conan bintray urls require that the username be all lowercase.

### DIFF
--- a/conan/packager.py
+++ b/conan/packager.py
@@ -138,6 +138,14 @@ class ConanMultiPackager(object):
 
         self.remotes = remotes or os.getenv("CONAN_REMOTES", [])
         self.upload = upload or os.getenv("CONAN_UPLOAD", None)
+        # The username portion of the remote URLs must be all lowercase to work
+        if self.remotes != None:
+            if isinstance(self.remotes,list):
+                self.remotes = [remote.lower() for remote in self.remotes]
+            else:
+                self.remotes = self.remotes.lower()
+        if self.upload != None:
+            self.upload = self.upload.lower()
 
         self.stable_branch_pattern = stable_branch_pattern or \
                                      os.getenv("CONAN_STABLE_BRANCH_PATTERN", None)

--- a/conan/test/packager_test.py
+++ b/conan/test/packager_test.py
@@ -301,6 +301,41 @@ class AppTest(unittest.TestCase):
         self.assertTrue("x86" in builder.named_builds)
         self.assertTrue("x86_64" in builder.named_builds)
 
+    # Conan remote URLs require the username the be in all lowercase
+    def test_url_handling(self):
+        runner = MockRunner()
+        builder = ConanMultiPackager(username="Pepe",
+                                     remotes=["URL1", "URL2"],
+                                     upload="URL",
+                                     runner=runner)
+        builder.add({}, {}, {}, {})
+        builder.run_builds()
+        print(runner.calls)
+        self.assertIn('conan remote add remote0 url2 --insert', runner.calls)
+        self.assertIn('conan remote add remote1 url1 --insert', runner.calls)
+        self.assertIn('conan remote add upload_repo url', runner.calls)
+
+        runner = MockRunner()
+        builder = ConanMultiPackager(username="Pepe",
+                                     remotes="URL1, URL2",
+                                     upload="URL",
+                                     runner=runner)
+        builder.add({}, {}, {}, {})
+        builder.run_builds()
+        self.assertIn('conan remote add remote0 url2 --insert', runner.calls)
+        self.assertIn('conan remote add remote1 url1 --insert', runner.calls)
+        self.assertIn('conan remote add upload_repo url', runner.calls)
+
+        runner = MockRunner()
+        builder = ConanMultiPackager(username="Pepe",
+                                     remotes="URL1",
+                                     upload="URL",
+                                     runner=runner)
+        builder.add({}, {}, {}, {})
+        builder.run_builds()
+        self.assertIn('conan remote add remote0 url1 --insert', runner.calls)
+        self.assertIn('conan remote add upload_repo url', runner.calls)
+
     def test_remotes(self):
         runner = MockRunner()
         builder = ConanMultiPackager(username="Pepe",


### PR DESCRIPTION
Unexpected crashes occur otherwise. This adds a little robustness so that URLs with uppercase letters in the usernames will be handled properly.
For an example of what can happen, look at the logs here: https://travis-ci.org/DEGoodmanWilson/conan-base64/jobs/326793945