### PR TITLE
Full options dictionary support

### DIFF
--- a/conan/builds_generator.py
+++ b/conan/builds_generator.py
@@ -97,11 +97,10 @@ def get_visual_builds_for_version(visual_runtimes, visual_version, arch, dll_wit
     sets = []
     shared_option_name = ""
 
-    common_options_without_shared = dict()
-    for key in common_options.keys():
+    common_options_without_shared = copy.copy(common_options)
+    for key in common_options_without_shared.keys():
         if "shared" in key.lower():
             shared_option_name = key
-            common_options_without_shared = copy.copy(common_options)
             del common_options_without_shared[key]
             break
 

--- a/conan/builds_generator.py
+++ b/conan/builds_generator.py
@@ -27,7 +27,7 @@ class BuildConf(namedtuple("BuildConf", "settings options env_vars build_require
 
 
 def get_mingw_builds(mingw_configurations, mingw_installer_reference,
-                     archs, shared_option_name, build_types, reference=None):
+                     archs, build_types, common_options, reference=None):
     builds = []
     for config in mingw_configurations:
         version, arch, exception, thread = config
@@ -38,16 +38,20 @@ def get_mingw_builds(mingw_configurations, mingw_installer_reference,
                     "compiler.threads": thread,
                     "compiler.exception": exception}
         build_requires = {"*": [mingw_installer_reference]}
-        options = {}
 
-        if shared_option_name:
-            for shared in [True, False]:
-                opt = copy.copy(options)
-                opt[shared_option_name] = shared
-                builds += _make_mingw_builds(settings, opt, build_requires, build_types, reference)
+        if common_options:
+            for combination in _combine_common_options(common_options):
+                builds += _make_mingw_builds(settings=settings,
+                                             options=_option_dict_from_combination(combination),
+                                             build_requires=build_requires,
+                                             build_types=build_types,
+                                             reference=reference)
         else:
-            builds += _make_mingw_builds(settings, options, build_requires, build_types, reference)
-
+            builds += _make_mingw_builds(settings=settings,
+                                         options={},
+                                         build_requires=build_requires,
+                                         build_types=build_types,
+                                         reference=reference)
     return builds
 
 
@@ -63,29 +67,43 @@ def _make_mingw_builds(settings, options, build_requires, build_types, reference
     return builds
 
 
-def get_visual_builds(visual_versions, archs, visual_runtimes, shared_option_name,
-                      dll_with_static_runtime, vs10_x86_64_enabled, build_types, reference=None):
+def get_visual_builds(visual_versions, archs, visual_runtimes,
+                      dll_with_static_runtime, vs10_x86_64_enabled, build_types, common_options,
+                      reference=None):
     ret = []
     for visual_version in visual_versions:
         visual_version = str(visual_version)
         for arch in archs:
             if not vs10_x86_64_enabled and arch == "x86_64" and visual_version == "10":
                 continue
-            visual_builds = get_visual_builds_for_version(visual_runtimes, visual_version, arch,
-                                                          shared_option_name,
-                                                          dll_with_static_runtime, build_types,
-                                                          reference)
+            visual_builds = get_visual_builds_for_version(visual_runtimes=visual_runtimes,
+                                                          visual_version=visual_version,
+                                                          arch=arch,
+                                                          dll_with_static_runtime=dll_with_static_runtime,
+                                                          build_types=build_types,
+                                                          common_options=common_options,
+                                                          reference=reference)
 
             ret.extend(visual_builds)
     return ret
 
 
-def get_visual_builds_for_version(visual_runtimes, visual_version, arch, shared_option_name,
-                                  dll_with_static_runtime, build_types, reference=None):
+def get_visual_builds_for_version(visual_runtimes, visual_version, arch, dll_with_static_runtime,
+                                  build_types, common_options, reference=None):
     base_set = {"compiler": "Visual Studio",
                 "compiler.version": visual_version,
                 "arch": arch}
+
     sets = []
+    shared_option_name = ""
+
+    common_options_without_shared = dict()
+    for key in common_options.keys():
+        if "shared" in key.lower():
+            shared_option_name = key
+            common_options_without_shared = copy.copy(common_options)
+            del common_options_without_shared[key]
+            break
 
     if shared_option_name:
         if "MT" in visual_runtimes and "Release" in build_types:
@@ -110,7 +128,6 @@ def get_visual_builds_for_version(visual_runtimes, visual_version, arch, shared_
                                   {shared_option_name: False}, {}, {}))
             sets.append(({"build_type": "Debug", "compiler.runtime": "MDd"},
                                   {shared_option_name: True}, {}, {}))
-
     else:
         if "MT" in visual_runtimes and "Release" in build_types:
             sets.append(({"build_type": "Release", "compiler.runtime": "MT"}, {}, {}, {}))
@@ -125,17 +142,19 @@ def get_visual_builds_for_version(visual_runtimes, visual_version, arch, shared_
     for setting, options, env_vars, build_requires in sets:
         tmp = copy.copy(base_set)
         tmp.update(setting)
-        ret.append(BuildConf(tmp, options, env_vars, build_requires, reference))
-
+        if common_options_without_shared:
+            for combination in _combine_common_options(common_options_without_shared):
+                opt = copy.copy(options)
+                opt.update(_option_dict_from_combination(combination))
+                ret.append(BuildConf(tmp, opt, env_vars, build_requires, reference))
+        else:
+            ret.append(BuildConf(tmp, options, env_vars, build_requires, reference))
     return ret
 
 
-def get_build(compiler, the_arch, the_build_type, the_compiler_version,
-              the_libcxx, the_shared_option_name,
-              the_shared, reference):
-    options = {}
-    if the_shared_option_name:
-        options = {the_shared_option_name: the_shared}
+def get_build(compiler, the_arch, the_build_type, the_compiler_version, the_libcxx, reference,
+              common_options):
+    options = common_options
     setts = {"arch": the_arch,
              "build_type": the_build_type,
              "compiler": compiler,
@@ -146,95 +165,191 @@ def get_build(compiler, the_arch, the_build_type, the_compiler_version,
     return BuildConf(setts, options, {}, {}, reference)
 
 
-def get_osx_apple_clang_builds(apple_clang_versions, archs, shared_option_name,
-                               pure_c, build_types, reference=None):
+def get_osx_apple_clang_builds(apple_clang_versions, archs, pure_c, build_types, common_options,
+                               reference=None):
     ret = []
     # Not specified compiler or compiler version, will use the auto detected
     for compiler_version in apple_clang_versions:
         for arch in archs:
-            if shared_option_name:
-                for shared in [True, False]:
-                    for build_type_it in build_types:
-                        if not pure_c:
-                            ret.append(get_build("apple-clang", arch, build_type_it,
-                                                 compiler_version,
-                                                 "libc++", shared_option_name, shared, reference))
-                        else:
-                            ret.append(get_build("apple-clang", arch, build_type_it,
-                                                 compiler_version, None, shared_option_name,
-                                                 shared, reference))
-            else:
-                for build_type_it in build_types:
-                    if not pure_c:
-                        ret.append(get_build("apple-clang", arch, build_type_it,
-                                             compiler_version, "libc++", None, None, reference))
-                    else:
-                        ret.append(get_build("apple-clang", arch, build_type_it,
-                                             compiler_version, None, None, None, reference))
-
+            for build_type_it in build_types:
+                if common_options:
+                    for combination in _combine_common_options(common_options):
+                        ret.append(get_build(compiler="apple-clang",
+                                             the_arch=arch,
+                                             the_build_type=build_type_it,
+                                             the_compiler_version=compiler_version,
+                                             the_libcxx="libc++" if not pure_c else None,
+                                             reference=reference,
+                                             common_options=_option_dict_from_combination(combination)))
+                else:
+                    ret.append(get_build(compiler="apple-clang",
+                                         the_arch=arch,
+                                         the_build_type=build_type_it,
+                                         the_compiler_version=compiler_version,
+                                         the_libcxx="libc++" if not pure_c else None,
+                                         reference=reference,
+                                         common_options={}))
     return ret
 
 
-def get_linux_gcc_builds(gcc_versions, archs, shared_option_name, pure_c, build_types,
-                         reference=None):
+def _combine_common_options(common_options):
+    """
+    Get all the combinations for common options. Returns a list of tuples with the combination of
+    key - value.
+
+    Keyword arguments:
+    common_options -- Dictionary with options and possible values as in a recipe: {"my_option": [True, False]}
+    """
+
+    expanded_options = list()
+    for key in common_options:
+        internal_list = list()
+        for value in common_options[key]:
+            internal_list.append((key, value))
+        expanded_options.append(internal_list)
+
+    combinations = list()
+    if len(common_options) == 1:
+        for option in expanded_options[0]:
+            combinations.append(option)
+        return combinations
+
+    import itertools
+    combinations = itertools.product(*expanded_options)
+    return list(combinations)
+
+
+def _option_dict_from_combination(combination):
+    """
+    Returns a dictionary with the fixed key-value from an option combination.
+
+    Keyword arguments:
+    combination -- List of tuples with the fixed combinations: (("shared", True), ("my_option", False))
+    """
+    option_dict = dict()
+    try:
+        for comb in combination:
+            option_dict[comb[0]] = comb[1]
+    except:
+        option_dict.clear()
+        option_dict[combination[0]] = combination[1]
+    return option_dict
+
+
+def get_linux_gcc_builds(gcc_versions, archs, pure_c, build_types, common_options, reference=None):
     ret = []
     # Not specified compiler or compiler version, will use the auto detected
     for gcc_version in gcc_versions:
         for arch in archs:
-            if shared_option_name:
-                for shared in [True, False]:
-                    for build_type_it in build_types:
+            for build_type_it in build_types:
+                if common_options:
+                    for combination in _combine_common_options(common_options):
                         if not pure_c:
-                            ret.append(get_build("gcc", arch, build_type_it, gcc_version,
-                                                 "libstdc++", shared_option_name, shared,
-                                                 reference))
+                            ret.append(get_build(compiler="gcc",
+                                                 the_arch=arch,
+                                                 the_build_type=build_type_it,
+                                                 the_compiler_version=gcc_version,
+                                                 the_libcxx="libstdc++", 
+                                                 reference=reference,
+                                                 common_options=_option_dict_from_combination(combination)))
                             if float(gcc_version) >= 5:
-                                ret.append(get_build("gcc", arch, build_type_it, gcc_version,
-                                                     "libstdc++11", shared_option_name, shared,
-                                                     reference))
+                                ret.append(get_build(compiler="gcc",
+                                                     the_arch=arch,
+                                                     the_build_type=build_type_it,
+                                                     the_compiler_version=gcc_version,
+                                                     the_libcxx="libstdc++11", 
+                                                     reference=reference,
+                                                     common_options=_option_dict_from_combination(combination)))
                         else:
-                            ret.append(get_build("gcc", arch, build_type_it, gcc_version,
-                                                 None, shared_option_name, shared, reference))
-            else:
-                for build_type_it in build_types:
+                            ret.append(get_build(compiler="gcc",
+                                                 the_arch=arch,
+                                                 the_build_type=build_type_it,
+                                                 the_compiler_version=gcc_version,
+                                                 the_libcxx=None, 
+                                                 reference=reference,
+                                                 common_options=_option_dict_from_combination(combination)))
+                else:
                     if not pure_c:
-                        ret.append(get_build("gcc", arch, build_type_it, gcc_version,
-                                             "libstdc++", None, None, reference))
+                        ret.append(get_build(compiler="gcc",
+                                             the_arch=arch,
+                                             the_build_type=build_type_it,
+                                             the_compiler_version=gcc_version,
+                                             the_libcxx="libstdc++", 
+                                             reference=reference,
+                                             common_options={}))
                         if float(gcc_version) >= 5:
-                            ret.append(get_build("gcc", arch, build_type_it, gcc_version,
-                                                 "libstdc++11", None, None, reference))
+                            ret.append(get_build(compiler="gcc",
+                                                 the_arch=arch,
+                                                 the_build_type=build_type_it,
+                                                 the_compiler_version=gcc_version,
+                                                 the_libcxx="libstdc++11", 
+                                                 reference=reference,
+                                                 common_options={}))
                     else:
-                        ret.append(get_build("gcc", arch, build_type_it, gcc_version, None,
-                                             None, None, reference))
+                        ret.append(get_build(compiler="gcc",
+                                             the_arch=arch,
+                                             the_build_type=build_type_it,
+                                             the_compiler_version=gcc_version,
+                                             the_libcxx=None, 
+                                             reference=reference,
+                                             common_options={}))
     return ret
 
 
-def get_linux_clang_builds(clang_versions, archs, shared_option_name, pure_c, build_types,
+def get_linux_clang_builds(clang_versions, archs, pure_c, build_types, common_options,
                            reference=None):
     ret = []
     # Not specified compiler or compiler version, will use the auto detected
     for clang_version in clang_versions:
         for arch in archs:
-            if shared_option_name:
-                for shared in [True, False]:
-                    for build_type_it in build_types:
+            for build_type_it in build_types:
+                if common_options:
+                    for combination in _combine_common_options(common_options):
                         if not pure_c:
-                            ret.append(get_build("clang", arch, build_type_it, clang_version,
-                                                 "libstdc++", shared_option_name, shared,
-                                                 reference))
-                            ret.append(get_build("clang", arch, build_type_it, clang_version,
-                                                 "libc++", shared_option_name, shared, reference))
+                            ret.append(get_build(compiler="clang",
+                                                 the_arch=arch,
+                                                 the_build_type=build_type_it,
+                                                 the_compiler_version=clang_version,
+                                                 the_libcxx="libstdc++",
+                                                 reference=reference,
+                                                 common_options=_option_dict_from_combination(combination)))
+                            ret.append(get_build(compiler="clang",
+                                                 the_arch=arch,
+                                                 the_build_type=build_type_it,
+                                                 the_compiler_version=clang_version,
+                                                 the_libcxx="libc++",
+                                                 reference=reference,
+                                                 common_options=_option_dict_from_combination(combination)))
                         else:
-                            ret.append(get_build("clang", arch, build_type_it, clang_version,
-                                                 None, shared_option_name, shared, reference))
-            else:
-                for build_type_it in build_types:
+                            ret.append(get_build(compiler="clang",
+                                                 the_arch=arch,
+                                                 the_build_type=build_type_it,
+                                                 the_compiler_version=clang_version,
+                                                 the_libcxx=None,
+                                                 reference=reference,
+                                                 common_options=_option_dict_from_combination(combination)))
+                else:
                     if not pure_c:
-                        ret.append(get_build("clang", arch, build_type_it, clang_version,
-                                             "libstdc++", None, None, reference))
-                        ret.append(get_build("clang", arch, build_type_it, clang_version,
-                                             "libc++", None, None, reference))
+                            ret.append(get_build(compiler="clang",
+                                                 the_arch=arch,
+                                                 the_build_type=build_type_it,
+                                                 the_compiler_version=clang_version,
+                                                 the_libcxx="libstdc++",
+                                                 reference=reference,
+                                                 common_options={}))
+                            ret.append(get_build(compiler="clang",
+                                                 the_arch=arch,
+                                                 the_build_type=build_type_it,
+                                                 the_compiler_version=clang_version,
+                                                 the_libcxx="libc++",
+                                                 reference=reference,
+                                                 common_options={}))
                     else:
-                        ret.append(get_build("clang", arch, build_type_it, clang_version,
-                                             None, None, None, reference))
+                        ret.append(get_build(compiler="clang",
+                                                the_arch=arch,
+                                                the_build_type=build_type_it,
+                                                the_compiler_version=clang_version,
+                                                the_libcxx=None,
+                                                reference=reference,
+                                                common_options={}))
     return ret

--- a/conan/packager.py
+++ b/conan/packager.py
@@ -368,43 +368,72 @@ won't be able to use them.
                     self._named_builds.setdefault(key, []).append(BuildConf(*values))
 
     def add_common_builds(self, shared_option_name=None, pure_c=True,
-                          dll_with_static_runtime=False, reference=None):
+                          dll_with_static_runtime=False, reference=None, common_options=None):
 
         reference = reference or self.reference
+        common_options = common_options or {}
+
+        if shared_option_name:
+            common_options[shared_option_name] = [True, False]
 
         builds = []
         if self.use_docker:
-            builds = get_linux_gcc_builds(self.gcc_versions, self.archs, shared_option_name,
-                                          pure_c, self.build_types, reference)
-            builds.extend(get_linux_clang_builds(self.clang_versions, self.archs,
-                                                 shared_option_name, pure_c, self.build_types,
-                                                 reference))
+            builds = get_linux_gcc_builds(gcc_versions=self.gcc_versions,
+                                          archs=self.archs,
+                                          pure_c=pure_c,
+                                          build_types=self.build_types,
+                                          common_options=common_options,
+                                          reference=reference)
+            builds.extend(get_linux_clang_builds(clang_versions=self.clang_versions,
+                                                 archs=self.archs,
+                                                 pure_c=pure_c,
+                                                 build_types=self.build_types,
+                                                 common_options=common_options,
+                                                 reference=reference))
         else:
             if self._platform_info.system() == "Windows":
                 if self.mingw_configurations:
-                    builds = get_mingw_builds(self.mingw_configurations,
-                                              self.mingw_installer_reference, self.archs,
-                                              shared_option_name, self.build_types, reference)
-                builds.extend(get_visual_builds(self.visual_versions, self.archs,
-                                                self.visual_runtimes,
-                                                shared_option_name, dll_with_static_runtime,
-                                                self.vs10_x86_64_enabled, self.build_types,
-                                                reference))
+                    builds = get_mingw_builds(mingw_configurations=self.mingw_configurations,
+                                              mingw_installer_reference=self.mingw_installer_reference,
+                                              archs=self.archs,
+                                              build_types=self.build_types,
+                                              common_options=common_options,
+                                              reference=reference)
+                builds.extend(get_visual_builds(visual_versions=self.visual_versions,
+                                                archs=self.archs,
+                                                visual_runtimes=self.visual_runtimes,
+                                                dll_with_static_runtime=dll_with_static_runtime,
+                                                vs10_x86_64_enabled=self.vs10_x86_64_enabled,
+                                                build_types=self.build_types,
+                                                common_options=common_options,
+                                                reference=reference))
             elif self._platform_info.system() == "Linux":
-                builds = get_linux_gcc_builds(self.gcc_versions, self.archs, shared_option_name,
-                                              pure_c, self.build_types, reference)
-                builds.extend(get_linux_clang_builds(self.clang_versions, self.archs,
-                                                     shared_option_name, pure_c,
-                                                     self.build_types, reference))
+                builds = get_linux_gcc_builds(gcc_versions=self.gcc_versions,
+                                              archs=self.archs,
+                                              pure_c=pure_c,
+                                              build_types=self.build_types,
+                                              common_options=common_options,
+                                              reference=reference)
+                builds.extend(get_linux_clang_builds(clang_versions=self.clang_versions,
+                                                     archs=self.archs,
+                                                     pure_c=pure_c,
+                                                     build_types=self.build_types,
+                                                     common_options=common_options,
+                                                     reference=reference))
             elif self._platform_info.system() == "Darwin":
-                builds = get_osx_apple_clang_builds(self.apple_clang_versions, self.archs,
-                                                    shared_option_name, pure_c, self.build_types,
-                                                    reference)
+                builds = get_osx_apple_clang_builds(apple_clang_versions=self.apple_clang_versions,
+                                                    archs=self.archs,
+                                                    pure_c=pure_c,
+                                                    build_types=self.build_types,
+                                                    common_options=common_options,
+                                                    reference=reference)
             elif self._platform_info.system() == "FreeBSD":
-                builds = get_linux_clang_builds(self.clang_versions, self.archs,
-                                                shared_option_name, pure_c, self.build_types,
-                                                reference)
-
+                builds = get_linux_clang_builds(clang_versions=self.clang_versions,
+                                                archs=self.archs,
+                                                pure_c=pure_c,
+                                                build_types=self.build_types,
+                                                common_options=common_options,
+                                                reference=reference)
         self._builds.extend(builds)
 
     def add(self, settings=None, options=None, env_vars=None, build_requires=None, reference=None):

--- a/conan/test/generators_test.py
+++ b/conan/test/generators_test.py
@@ -581,14 +581,16 @@ class GeneratorsTest(unittest.TestCase):
     def options_test(self):
         options = {"shared": [True, False], "opt": [True, False]}
         combinations = _combine_common_options(options)
-        self.assertEquals(combinations, [(("shared", True), ("opt", True)),
-                                         (("shared", True), ("opt", False)),
-                                         (("shared", False), ("opt", True)),
-                                         (("shared", False), ("opt", False))])
+        output = [set(comb) for comb in combinations]
+        expected = [{("opt", True), ("shared", True)}, {("opt", False), ("shared", True)},
+                    {("opt", True), ("shared", False)}, {("opt", False), ("shared", False)}]
+        self.assertEquals(output, expected)
 
         options = {"shared": [True, False]}
         combinations = _combine_common_options(options)
-        self.assertEquals(combinations, [(("shared", True)), (("shared", False))])
+        output = [comb for comb in combinations]
+        expected = [("shared", True), ("shared", False)]
+        self.assertEquals(output, expected)
 
 
         expanded_option1 = (("shared", True), ("opt", True))

--- a/conan/test/generators_test.py
+++ b/conan/test/generators_test.py
@@ -602,3 +602,45 @@ class GeneratorsTest(unittest.TestCase):
         single_expanded_option = (("shared", True))
         option_dict = _option_dict_from_combination(single_expanded_option)
         self.assertEqual(option_dict, {"shared": True})
+
+    def functional_options_test(self):
+        ref = ConanFileReference.loads("lib/1.0@conan/stable")
+        builds = get_visual_builds(visual_versions=["14"],
+                                   archs=["x86"],
+                                   visual_runtimes=["MDd"],
+                                   dll_with_static_runtime=False,
+                                   vs10_x86_64_enabled=True,
+                                   build_types=["Debug"],
+                                   common_options={"opt1":[True, False], "opt2":["value1", "value2"]},
+                                   reference=ref)
+
+        expected = [
+        ({'arch': 'x86', 'build_type': 'Debug', 'compiler': 'Visual Studio', 'compiler.version': '14', 'compiler.runtime': 'MDd'}, {"opt1":True, "opt2":"value1"}, {}, {}, ref),
+        ({'arch': 'x86', 'build_type': 'Debug', 'compiler': 'Visual Studio', 'compiler.version': '14', 'compiler.runtime': 'MDd'}, {"opt1":True, "opt2":"value2"}, {}, {}, ref),
+        ({'arch': 'x86', 'build_type': 'Debug', 'compiler': 'Visual Studio', 'compiler.version': '14', 'compiler.runtime': 'MDd'}, {"opt1":False, "opt2":"value1"}, {}, {}, ref),
+        ({'arch': 'x86', 'build_type': 'Debug', 'compiler': 'Visual Studio', 'compiler.version': '14', 'compiler.runtime': 'MDd'}, {"opt1":False, "opt2":"value2"}, {}, {}, ref)]
+
+        self.assertEquals([tuple(a) for a in builds], expected)
+
+
+        ref = ConanFileReference.loads("lib/2.3@conan/stable")
+        builds = get_linux_clang_builds(clang_versions=["4.0"],
+                                        archs=["x86_64"],
+                                        pure_c=True,
+                                        build_types=["Debug"],
+                                        common_options={"pack:shared":[True, False], "my_option":[True, False, "other"]},
+                                        reference=ref)
+        expected = [({'arch': 'x86_64', 'build_type': 'Debug', 'compiler': 'clang', 'compiler.version': '4.0'},
+                     {'pack:shared': True, "my_option":True}, {}, {}, ref),
+                    ({'arch': 'x86_64', 'build_type': 'Debug','compiler': 'clang', 'compiler.version': '4.0'},
+                     {'pack:shared': True, "my_option":False}, {}, {}, ref),
+                    ({'arch': 'x86_64', 'build_type': 'Debug', 'compiler': 'clang', 'compiler.version': '4.0'},
+                     {'pack:shared': True, "my_option":"other"}, {}, {}, ref),
+                    ({'arch': 'x86_64', 'build_type': 'Debug', 'compiler': 'clang', 'compiler.version': '4.0'},
+                     {'pack:shared': False, "my_option":True}, {}, {}, ref),
+                    ({'arch': 'x86_64', 'build_type': 'Debug', 'compiler': 'clang', 'compiler.version': '4.0'},
+                     {'pack:shared': False, "my_option":False}, {}, {}, ref),
+                    ({'arch': 'x86_64', 'build_type': 'Debug', 'compiler': 'clang', 'compiler.version': '4.0'},
+                     {'pack:shared': False, "my_option":"other"}, {}, {}, ref)]
+        b = [tuple(a) for a in builds]
+        self.assertEquals(b, expected)

--- a/conan/test/generators_test.py
+++ b/conan/test/generators_test.py
@@ -1,6 +1,6 @@
 import unittest
 
-from conan.builds_generator import get_visual_builds, get_mingw_builds, get_osx_apple_clang_builds, get_linux_gcc_builds, get_linux_clang_builds
+from conan.builds_generator import get_visual_builds, get_mingw_builds, get_osx_apple_clang_builds, get_linux_gcc_builds, get_linux_clang_builds, _combine_common_options, _option_dict_from_combination
 from conans.model.ref import ConanFileReference
 
 
@@ -10,9 +10,11 @@ class GeneratorsTest(unittest.TestCase):
 
         mingw_configurations = [("4.9", "x86", "dwarf2", "posix")]
         ref = ConanFileReference.loads("lib/1.0@conan/stable")
-        builds = get_mingw_builds(mingw_configurations,
-                                  ConanFileReference.loads("mingw_installer/1.0@conan/stable"),
-                                  ["x86"], "pack:shared", ["Release", "Debug"],
+        builds = get_mingw_builds(mingw_configurations=mingw_configurations,
+                                  mingw_installer_reference=ConanFileReference.loads("mingw_installer/1.0@conan/stable"),
+                                  archs=["x86"],
+                                  build_types=["Release", "Debug"],
+                                  common_options={"pack:shared":[True, False]},
                                   reference=ref)
         expected = [
             ({'build_type': 'Release', 'compiler.version': '4.9', 'compiler.libcxx': "libstdc++",
@@ -43,8 +45,11 @@ class GeneratorsTest(unittest.TestCase):
 
         self.assertEquals([tuple(a) for a in builds], expected)
 
-        builds = get_mingw_builds(mingw_configurations, ConanFileReference.loads(
-            "mingw_installer/1.0@conan/stable"), ["x86"], "pack:shared", ["Release"])
+        builds = get_mingw_builds(mingw_configurations=mingw_configurations,
+                                  mingw_installer_reference=ConanFileReference.loads("mingw_installer/1.0@conan/stable"),
+                                  archs=["x86"],
+                                  build_types=["Release"],
+                                  common_options={"pack:shared":[True, False]})
         expected = [
             ({'build_type': 'Release', 'compiler.version': '4.9', 'compiler.libcxx': "libstdc++",
               'compiler': 'gcc', 'arch': 'x86', 'compiler.exception': 'dwarf2',
@@ -61,8 +66,11 @@ class GeneratorsTest(unittest.TestCase):
 
         self.assertEquals([tuple(a) for a in builds], expected)
 
-        builds = get_mingw_builds(mingw_configurations, ConanFileReference.loads(
-            "mingw_installer/1.0@conan/stable"), ["x86"], "pack:shared", ["Debug"])
+        builds = get_mingw_builds(mingw_configurations=mingw_configurations,
+                                  mingw_installer_reference=ConanFileReference.loads("mingw_installer/1.0@conan/stable"),
+                                  archs=["x86"],
+                                  build_types=["Debug"],
+                                  common_options={"pack:shared":[True, False]})
         expected = [
             ({'compiler.version': '4.9', 'compiler': 'gcc', 'compiler.libcxx': "libstdc++",
               'build_type': 'Debug', 'compiler.exception': 'dwarf2', 'compiler.threads': 'posix',
@@ -81,33 +89,46 @@ class GeneratorsTest(unittest.TestCase):
 
     def test_get_osx_apple_clang_builds(self):
         ref = ConanFileReference.loads("lib/1.0@conan/stable")
-        builds = get_osx_apple_clang_builds(["8.0"], ["x86_64"], "pack:shared", pure_c=False, build_types=["Debug", "Release"], reference=ref)
+        builds = get_osx_apple_clang_builds(apple_clang_versions=["8.0"],
+                                            archs=["x86_64"],
+                                            pure_c=False,
+                                            build_types=["Debug", "Release"],
+                                            common_options={"pack:shared":[True, False]},
+                                            reference=ref)
         expected = [({'arch': 'x86_64', 'compiler.libcxx': 'libc++', 'compiler': 'apple-clang', 'compiler.version': '8.0', 'build_type': 'Debug'},
-                     {'pack:shared': True}, {}, {}, ref),
-                    ({'arch': 'x86_64', 'compiler.libcxx': 'libc++', 'compiler': 'apple-clang', 'compiler.version': '8.0', 'build_type': 'Release'},
                      {'pack:shared': True}, {}, {}, ref),
                     ({'arch': 'x86_64', 'compiler.libcxx': 'libc++', 'compiler': 'apple-clang', 'compiler.version': '8.0', 'build_type': 'Debug'},
                      {'pack:shared': False}, {}, {}, ref),
                     ({'arch': 'x86_64', 'compiler.libcxx': 'libc++', 'compiler': 'apple-clang', 'compiler.version': '8.0', 'build_type': 'Release'},
+                     {'pack:shared': True}, {}, {}, ref),
+                    ({'arch': 'x86_64', 'compiler.libcxx': 'libc++', 'compiler': 'apple-clang', 'compiler.version': '8.0', 'build_type': 'Release'},
                      {'pack:shared': False}, {}, {}, ref)]
         self.assertEquals([tuple(a) for a in builds], expected)
 
-        builds = get_osx_apple_clang_builds(["8.0"], ["x86_64"], "pack:shared", pure_c=True, build_types=["Debug", "Release"])
+        builds = get_osx_apple_clang_builds(apple_clang_versions=["8.0"],
+                                            archs=["x86_64"],
+                                            pure_c=True,
+                                            build_types=["Debug", "Release"],
+                                            common_options={"pack:shared": [True, False]})
         expected = [({'arch': 'x86_64', 'compiler': 'apple-clang',
                       'compiler.version': '8.0', 'build_type': 'Debug'},
-                     {'pack:shared': True}, {}, {}, None),
-                    ({'arch': 'x86_64', 'compiler': 'apple-clang',
-                      'compiler.version': '8.0', 'build_type': 'Release'},
                      {'pack:shared': True}, {}, {}, None),
                     ({'arch': 'x86_64', 'compiler': 'apple-clang',
                       'compiler.version': '8.0', 'build_type': 'Debug'},
                      {'pack:shared': False}, {}, {}, None),
                     ({'arch': 'x86_64', 'compiler': 'apple-clang',
                       'compiler.version': '8.0', 'build_type': 'Release'},
+                     {'pack:shared': True}, {}, {}, None),
+                    ({'arch': 'x86_64', 'compiler': 'apple-clang',
+                      'compiler.version': '8.0', 'build_type': 'Release'},
                      {'pack:shared': False}, {}, {}, None)]
         self.assertEquals([tuple(a) for a in builds], expected)
 
-        builds = get_osx_apple_clang_builds(["8.0"], ["x86_64"], "pack:shared", pure_c=False, build_types=["Debug"])
+        builds = get_osx_apple_clang_builds(apple_clang_versions=["8.0"],
+                                            archs=["x86_64"],
+                                            pure_c=False,
+                                            build_types=["Debug"],
+                                            common_options={"pack:shared": [True, False]})
         expected = [({'arch': 'x86_64', 'compiler.libcxx': 'libc++', 'compiler': 'apple-clang',
                       'compiler.version': '8.0', 'build_type': 'Debug'},
                      {'pack:shared': True}, {}, {}, None),
@@ -116,7 +137,11 @@ class GeneratorsTest(unittest.TestCase):
                      {'pack:shared': False}, {}, {}, None)]
         self.assertEquals([tuple(a) for a in builds], expected)
 
-        builds = get_osx_apple_clang_builds(["8.0"], ["x86_64"], "pack:shared", pure_c=True, build_types=["Release"])
+        builds = get_osx_apple_clang_builds(apple_clang_versions=["8.0"],
+                                            archs=["x86_64"],
+                                            pure_c=True,
+                                            build_types=["Release"],
+                                            common_options={"pack:shared":[True, False]})
         expected = [({'arch': 'x86_64', 'compiler': 'apple-clang',
                       'compiler.version': '8.0', 'build_type': 'Release'},
                      {'pack:shared': True}, {}, {}, None),
@@ -126,37 +151,49 @@ class GeneratorsTest(unittest.TestCase):
         self.assertEquals([tuple(a) for a in builds], expected)
 
     def test_get_linux_gcc_builds(self):
-        builds = get_linux_gcc_builds(["6"], ["x86_64"], "pack:shared", pure_c=False, build_types=["Debug", "Release"])
+        builds = get_linux_gcc_builds(gcc_versions=["6"],
+                                      archs=["x86_64"],
+                                      pure_c=False,
+                                      build_types=["Debug", "Release"],
+                                      common_options={"pack:shared": [True, False]})
         expected = [({'compiler': 'gcc', 'build_type': 'Debug', 'compiler.libcxx': 'libstdc++', 'compiler.version': '6', 'arch': 'x86_64'},
                      {'pack:shared': True}, {}, {}, None),
                     ({'compiler': 'gcc', 'build_type': 'Debug', 'compiler.libcxx': 'libstdc++11', 'compiler.version': '6', 'arch': 'x86_64'},
-                     {'pack:shared': True}, {}, {}, None),
-                    ({'compiler': 'gcc', 'build_type': 'Release', 'compiler.libcxx': 'libstdc++', 'compiler.version': '6', 'arch': 'x86_64'},
-                     {'pack:shared': True}, {}, {}, None),
-                    ({'compiler': 'gcc', 'build_type': 'Release', 'compiler.libcxx': 'libstdc++11', 'compiler.version': '6', 'arch': 'x86_64'},
                      {'pack:shared': True}, {}, {}, None),
                     ({'compiler': 'gcc', 'build_type': 'Debug', 'compiler.libcxx': 'libstdc++', 'compiler.version': '6', 'arch': 'x86_64'},
                      {'pack:shared': False}, {}, {}, None),
                     ({'compiler': 'gcc', 'build_type': 'Debug', 'compiler.libcxx': 'libstdc++11', 'compiler.version': '6', 'arch': 'x86_64'},
                      {'pack:shared': False}, {}, {}, None),
                     ({'compiler': 'gcc', 'build_type': 'Release', 'compiler.libcxx': 'libstdc++', 'compiler.version': '6', 'arch': 'x86_64'},
+                     {'pack:shared': True}, {}, {}, None),
+                    ({'compiler': 'gcc', 'build_type': 'Release', 'compiler.libcxx': 'libstdc++11', 'compiler.version': '6', 'arch': 'x86_64'},
+                     {'pack:shared': True}, {}, {}, None),
+                    ({'compiler': 'gcc', 'build_type': 'Release', 'compiler.libcxx': 'libstdc++', 'compiler.version': '6', 'arch': 'x86_64'},
                      {'pack:shared': False}, {}, {}, None),
                     ({'compiler': 'gcc', 'build_type': 'Release', 'compiler.libcxx': 'libstdc++11', 'compiler.version': '6', 'arch': 'x86_64'},
                      {'pack:shared': False}, {}, {}, None)]
         self.assertEquals([tuple(a) for a in builds], expected)
 
-        builds = get_linux_gcc_builds(["6"], ["x86_64"], "pack:shared", pure_c=True, build_types=["Debug", "Release"])
+        builds = get_linux_gcc_builds(gcc_versions=["6"],
+                                      archs=["x86_64"],
+                                      pure_c=True,
+                                      build_types=["Debug", "Release"],
+                                      common_options={"pack:shared":[True, False]})
         expected = [({'arch': 'x86_64', 'compiler.version': '6', 'build_type': 'Debug', 'compiler': 'gcc'},
-                     {'pack:shared': True}, {}, {}, None),
-                    ({'arch': 'x86_64', 'compiler.version': '6', 'build_type': 'Release', 'compiler': 'gcc'},
                      {'pack:shared': True}, {}, {}, None),
                     ({'arch': 'x86_64', 'compiler.version': '6', 'build_type': 'Debug', 'compiler': 'gcc'},
                      {'pack:shared': False}, {}, {}, None),
                     ({'arch': 'x86_64', 'compiler.version': '6', 'build_type': 'Release', 'compiler': 'gcc'},
+                     {'pack:shared': True}, {}, {}, None),
+                    ({'arch': 'x86_64', 'compiler.version': '6', 'build_type': 'Release', 'compiler': 'gcc'},
                      {'pack:shared': False}, {}, {}, None)]
         self.assertEquals([tuple(a) for a in builds], expected)
 
-        builds = get_linux_gcc_builds(["6"], ["x86_64"], "pack:shared", pure_c=False, build_types=["Debug"])
+        builds = get_linux_gcc_builds(gcc_versions=["6"],
+                                      archs=["x86_64"],
+                                      pure_c=False,
+                                      build_types=["Debug"],
+                                      common_options={"pack:shared":[True, False]})
         expected = [({'compiler': 'gcc', 'build_type': 'Debug', 'compiler.libcxx': 'libstdc++',
                       'compiler.version': '6', 'arch': 'x86_64'},
                      {'pack:shared': True}, {}, {}, None),
@@ -171,14 +208,22 @@ class GeneratorsTest(unittest.TestCase):
                      {'pack:shared': False}, {}, {}, None)]
         self.assertEquals([tuple(a) for a in builds], expected)
 
-        builds = get_linux_gcc_builds(["6"], ["x86_64"], "pack:shared", pure_c=True, build_types=["Debug"])
+        builds = get_linux_gcc_builds(gcc_versions=["6"],
+                                      archs=["x86_64"],
+                                      pure_c=True,
+                                      build_types=["Debug"],
+                                      common_options={"pack:shared":[True, False]})
         expected = [({'arch': 'x86_64', 'compiler.version': '6', 'build_type': 'Debug', 'compiler': 'gcc'},
                      {'pack:shared': True}, {}, {}, None),
                     ({'arch': 'x86_64', 'compiler.version': '6', 'build_type': 'Debug', 'compiler': 'gcc'},
                      {'pack:shared': False}, {}, {}, None)]
         self.assertEquals([tuple(a) for a in builds], expected)
 
-        builds = get_linux_gcc_builds(["6"], ["x86_64"], "pack:shared", pure_c=False, build_types=["Release"])
+        builds = get_linux_gcc_builds(gcc_versions=["6"],
+                                      archs=["x86_64"],
+                                      pure_c=False,
+                                      build_types=["Release"],
+                                      common_options={"pack:shared":[True, False]})
         expected = [({'compiler': 'gcc', 'build_type': 'Release', 'compiler.libcxx': 'libstdc++',
                       'compiler.version': '6', 'arch': 'x86_64'},
                      {'pack:shared': True}, {}, {}, None),
@@ -193,7 +238,11 @@ class GeneratorsTest(unittest.TestCase):
                      {'pack:shared': False}, {}, {}, None)]
         self.assertEquals([tuple(a) for a in builds], expected)
 
-        builds = get_linux_gcc_builds(["6"], ["x86_64"], "pack:shared", pure_c=True, build_types=["Release"])
+        builds = get_linux_gcc_builds(gcc_versions=["6"],
+                                      archs=["x86_64"],
+                                      pure_c=True,
+                                      build_types=["Release"],
+                                      common_options={"pack:shared":[True, False]})
         expected = [({'arch': 'x86_64', 'compiler.version': '6', 'build_type': 'Release', 'compiler': 'gcc'},
                      {'pack:shared': True}, {}, {}, None),
                     ({'arch': 'x86_64', 'compiler.version': '6', 'build_type': 'Release', 'compiler': 'gcc'},
@@ -203,42 +252,53 @@ class GeneratorsTest(unittest.TestCase):
     def test_get_linux_clang_builds(self):
         self.maxDiff = None
         ref = ConanFileReference.loads("lib/2.3@conan/stable")
-        builds = get_linux_clang_builds(["4.0"], ["x86_64"], "pack:shared", pure_c=False,
+        builds = get_linux_clang_builds(clang_versions=["4.0"],
+                                        archs=["x86_64"],
+                                        pure_c=False,
                                         build_types=["Debug", "Release"],
+                                        common_options={"pack:shared":[True, False]},
                                         reference=ref)
-        expected = [({'compiler': 'clang', 'build_type': 'Debug', 'compiler.libcxx': 'libstdc++', 'compiler.version': '4.0', 'arch': 'x86_64'},
+        expected = [({'arch': 'x86_64', 'build_type': 'Debug', 'compiler': 'clang', 'compiler.version': '4.0', 'compiler.libcxx': 'libstdc++'},
                      {'pack:shared': True}, {}, {}, ref),
-                    ({'compiler': 'clang', 'build_type': 'Debug', 'compiler.libcxx': 'libc++', 'compiler.version': '4.0', 'arch': 'x86_64'},
+                    ({'arch': 'x86_64', 'build_type': 'Debug','compiler': 'clang', 'compiler.version': '4.0', 'compiler.libcxx': 'libc++'},
                      {'pack:shared': True}, {}, {}, ref),
-                    ({'compiler': 'clang', 'build_type': 'Release', 'compiler.libcxx': 'libstdc++', 'compiler.version': '4.0', 'arch': 'x86_64'},
-                     {'pack:shared': True}, {}, {}, ref),
-                    ({'compiler': 'clang', 'build_type': 'Release', 'compiler.libcxx': 'libc++', 'compiler.version': '4.0', 'arch': 'x86_64'},
-                     {'pack:shared': True}, {}, {}, ref),
-                    ({'compiler': 'clang', 'build_type': 'Debug', 'compiler.libcxx': 'libstdc++', 'compiler.version': '4.0', 'arch': 'x86_64'},
+                    ({'arch': 'x86_64', 'build_type': 'Debug', 'compiler': 'clang', 'compiler.version': '4.0', 'compiler.libcxx': 'libstdc++'},
                      {'pack:shared': False}, {}, {}, ref),
-                    ({'compiler': 'clang', 'build_type': 'Debug', 'compiler.libcxx': 'libc++', 'compiler.version': '4.0', 'arch': 'x86_64'},
+                    ({'arch': 'x86_64', 'build_type': 'Debug', 'compiler': 'clang', 'compiler.version': '4.0', 'compiler.libcxx': 'libc++'},
                      {'pack:shared': False}, {}, {}, ref),
-                    ({'compiler': 'clang', 'build_type': 'Release', 'compiler.libcxx': 'libstdc++', 'compiler.version': '4.0', 'arch': 'x86_64'},
+                    ({'arch': 'x86_64', 'build_type': 'Release', 'compiler': 'clang', 'compiler.version': '4.0', 'compiler.libcxx': 'libstdc++'},
+                     {'pack:shared': True}, {}, {}, ref),
+                    ({'arch': 'x86_64', 'build_type': 'Release', 'compiler': 'clang', 'compiler.version': '4.0', 'compiler.libcxx': 'libc++'},
+                     {'pack:shared': True}, {}, {}, ref),
+                    ({'arch': 'x86_64', 'build_type': 'Release', 'compiler': 'clang', 'compiler.version': '4.0', 'compiler.libcxx': 'libstdc++'},
                      {'pack:shared': False}, {}, {}, ref),
-                    ({'compiler': 'clang', 'build_type': 'Release', 'compiler.libcxx': 'libc++', 'compiler.version': '4.0', 'arch': 'x86_64'},
+                    ({'arch': 'x86_64', 'build_type': 'Release', 'compiler': 'clang', 'compiler.version': '4.0', 'compiler.libcxx': 'libc++'},
                      {'pack:shared': False}, {}, {}, ref)]
         b = [tuple(a) for a in builds]
         self.assertEquals(b, expected)
 
-        builds = get_linux_clang_builds(["4.0"], ["x86_64"], "pack:shared", pure_c=True,
-                                        build_types=["Debug", "Release"], reference=ref)
+        builds = get_linux_clang_builds(clang_versions=["4.0"],
+                                        archs=["x86_64"],
+                                        pure_c=True,
+                                        build_types=["Debug", "Release"],
+                                        common_options={"pack:shared":[True, False]},
+                                        reference=ref)
         expected = [({'arch': 'x86_64', 'compiler.version': '4.0', 'build_type': 'Debug', 'compiler': 'clang'},
-                     {'pack:shared': True}, {}, {}, ref),
-                    ({'arch': 'x86_64', 'compiler.version': '4.0', 'build_type': 'Release', 'compiler': 'clang'},
                      {'pack:shared': True}, {}, {}, ref),
                     ({'arch': 'x86_64', 'compiler.version': '4.0', 'build_type': 'Debug', 'compiler': 'clang'},
                      {'pack:shared': False}, {}, {}, ref),
                     ({'arch': 'x86_64', 'compiler.version': '4.0', 'build_type': 'Release', 'compiler': 'clang'},
+                     {'pack:shared': True}, {}, {}, ref),
+                    ({'arch': 'x86_64', 'compiler.version': '4.0', 'build_type': 'Release', 'compiler': 'clang'},
                      {'pack:shared': False}, {}, {}, ref)]
         self.assertEquals([tuple(a) for a in builds], expected)
 
-        builds = get_linux_clang_builds(["4.0"], ["x86_64"], "pack:shared", pure_c=False,
-                                        build_types=["Debug"], reference=ref)
+        builds = get_linux_clang_builds(clang_versions=["4.0"],
+                                        archs=["x86_64"],
+                                        pure_c=False,
+                                        build_types=["Debug"],
+                                        common_options={"pack:shared":[True, False]},
+                                        reference=ref)
         expected = [({'compiler': 'clang', 'build_type': 'Debug', 'compiler.libcxx': 'libstdc++',
                       'compiler.version': '4.0', 'arch': 'x86_64'},
                      {'pack:shared': True}, {}, {}, ref),
@@ -253,15 +313,24 @@ class GeneratorsTest(unittest.TestCase):
                     {'pack:shared': False}, {}, {}, ref)]
         self.assertEquals([tuple(a) for a in builds], expected)
 
-        builds = get_linux_clang_builds(["4.0"], ["x86_64"], "pack:shared", pure_c=True,
-                                        build_types=["Debug"], reference=ref)
+        builds = get_linux_clang_builds(clang_versions=["4.0"],
+                                        archs=["x86_64"],
+                                        pure_c=True,
+                                        build_types=["Debug"],
+                                        common_options={"pack:shared":[True, False]},
+                                        reference=ref)
         expected = [({'arch': 'x86_64', 'compiler.version': '4.0', 'build_type': 'Debug', 'compiler': 'clang'},
                      {'pack:shared': True}, {}, {}, ref),
                     ({'arch': 'x86_64', 'compiler.version': '4.0', 'build_type': 'Debug', 'compiler': 'clang'},
                      {'pack:shared': False}, {}, {}, ref)]
         self.assertEquals([tuple(a) for a in builds], expected)
 
-        builds = get_linux_clang_builds(["4.0"], ["x86_64"], "pack:shared", pure_c=False, build_types=["Release"], reference=ref)
+        builds = get_linux_clang_builds(clang_versions=["4.0"],
+                                        archs=["x86_64"],
+                                        pure_c=False,
+                                        build_types=["Release"],
+                                        common_options={"pack:shared":[True, False]},
+                                        reference=ref)
         expected = [({'compiler': 'clang', 'build_type': 'Release', 'compiler.libcxx': 'libstdc++',
                       'compiler.version': '4.0', 'arch': 'x86_64'},
                      {'pack:shared': True}, {}, {}, ref),
@@ -278,7 +347,12 @@ class GeneratorsTest(unittest.TestCase):
                     {'pack:shared': False}, {}, {}, ref)]
         self.assertEquals([tuple(a) for a in builds], expected)
 
-        builds = get_linux_clang_builds(["4.0"], ["x86_64"], "pack:shared", pure_c=True, build_types=["Release"], reference=None)
+        builds = get_linux_clang_builds(clang_versions=["4.0"],
+                                        archs=["x86_64"],
+                                        pure_c=True,
+                                        build_types=["Release"],
+                                        common_options={"pack:shared":[True, False]},
+                                        reference=None)
         expected = [({'arch': 'x86_64', 'compiler.version': '4.0', 'build_type': 'Release', 'compiler': 'clang'},
                      {'pack:shared': True}, {}, {}, None),
                     ({'arch': 'x86_64', 'compiler.version': '4.0', 'build_type': 'Release', 'compiler': 'clang'},
@@ -287,11 +361,13 @@ class GeneratorsTest(unittest.TestCase):
 
     def test_visual_build_generator(self):
         ref = ConanFileReference.loads("lib/1.0@conan/stable")
-        builds = get_visual_builds(visual_versions=["10", "14"], archs=["x86"], visual_runtimes=["MDd", "MTd"],
-                                   shared_option_name=None,
+        builds = get_visual_builds(visual_versions=["10", "14"],
+                                   archs=["x86"],
+                                   visual_runtimes=["MDd", "MTd"],
                                    dll_with_static_runtime=False,
                                    vs10_x86_64_enabled=True,
                                    build_types=["Debug", "Release"],
+                                   common_options={},
                                    reference=ref)
 
         expected = [
@@ -302,11 +378,13 @@ class GeneratorsTest(unittest.TestCase):
 
         self.assertEquals([tuple(a) for a in builds], expected)
 
-        builds = get_visual_builds(visual_versions=["10"], archs=["x86", "x86_64"], visual_runtimes=["MDd"],
-                                   shared_option_name="libpng:shared",
+        builds = get_visual_builds(visual_versions=["10"],
+                                   archs=["x86", "x86_64"],
+                                   visual_runtimes=["MDd"],
                                    dll_with_static_runtime=True,
                                    vs10_x86_64_enabled=True,
-                                   build_types=["Debug", "Release"])
+                                   build_types=["Debug", "Release"],
+                                   common_options={"libpng:shared": [True, False]})
 
         expected = [
             ({'compiler.runtime': 'MDd', 'arch': 'x86', 'build_type': 'Debug', 'compiler': 'Visual Studio', 'compiler.version': '10'},
@@ -320,11 +398,13 @@ class GeneratorsTest(unittest.TestCase):
 
         self.assertEquals([tuple(a) for a in builds], expected)
 
-        builds = get_visual_builds(visual_versions=["10"], archs=["x86", "x86_64"], visual_runtimes=["MDd"],
-                                   shared_option_name="libpng:shared",
+        builds = get_visual_builds(visual_versions=["10"],
+                                   archs=["x86", "x86_64"],
+                                   visual_runtimes=["MDd"],
                                    dll_with_static_runtime=True,
                                    vs10_x86_64_enabled=False,
-                                   build_types=["Debug", "Release"])
+                                   build_types=["Debug", "Release"],
+                                   common_options={"libpng:shared": [True, False]})
         expected = [
         ({'compiler.runtime': 'MDd', 'arch': 'x86', 'build_type': 'Debug', 'compiler': 'Visual Studio', 'compiler.version': '10'},
           {'libpng:shared': False}, {}, {}, None),
@@ -333,22 +413,26 @@ class GeneratorsTest(unittest.TestCase):
 
         self.assertEquals([tuple(a) for a in builds], expected)
 
-        builds = get_visual_builds(visual_versions=["10"], archs=["x86", "x86_64"], visual_runtimes=["MTd"],
-                                   shared_option_name="libpng:shared",
+        builds = get_visual_builds(visual_versions=["10"],
+                                   archs=["x86", "x86_64"],
+                                   visual_runtimes=["MTd"],
                                    dll_with_static_runtime=False,
                                    vs10_x86_64_enabled=False,
-                                   build_types=["Debug", "Release"])
+                                   build_types=["Debug", "Release"],
+                                   common_options={"libpng:shared": [True, False]})
         expected = [
             ({'compiler': 'Visual Studio', 'compiler.runtime': 'MTd', 'compiler.version': '10', 'arch': 'x86', 'build_type': 'Debug'},
              {'libpng:shared': False}, {}, {}, None)]
 
         self.assertEquals([tuple(a) for a in builds], expected)
 
-        builds = get_visual_builds(visual_versions=["10", "14"], archs=["x86"], visual_runtimes=["MDd", "MTd"],
-                                   shared_option_name=None,
+        builds = get_visual_builds(visual_versions=["10", "14"],
+                                   archs=["x86"],
+                                   visual_runtimes=["MDd", "MTd"],
                                    dll_with_static_runtime=False,
                                    vs10_x86_64_enabled=True,
-                                   build_types=["Debug"])
+                                   build_types=["Debug"],
+                                   common_options={})
 
         expected = [
             ({'arch': 'x86', 'build_type': 'Debug', 'compiler': 'Visual Studio', 'compiler.version': '10',
@@ -362,11 +446,13 @@ class GeneratorsTest(unittest.TestCase):
 
         self.assertEquals([tuple(a) for a in builds], expected)
 
-        builds = get_visual_builds(visual_versions=["10"], archs=["x86", "x86_64"], visual_runtimes=["MDd"],
-                                   shared_option_name="libpng:shared",
+        builds = get_visual_builds(visual_versions=["10"],
+                                   archs=["x86", "x86_64"],
+                                   visual_runtimes=["MDd"],
                                    dll_with_static_runtime=True,
                                    vs10_x86_64_enabled=True,
-                                   build_types=["Debug"])
+                                   build_types=["Debug"],
+                                   common_options={"libpng:shared": [True, False]})
 
         expected = [
             ({'compiler.runtime': 'MDd', 'arch': 'x86', 'build_type': 'Debug', 'compiler': 'Visual Studio',
@@ -384,11 +470,13 @@ class GeneratorsTest(unittest.TestCase):
 
         self.assertEquals([tuple(a) for a in builds], expected)
 
-        builds = get_visual_builds(visual_versions=["10"], archs=["x86", "x86_64"], visual_runtimes=["MDd"],
-                                   shared_option_name="libpng:shared",
+        builds = get_visual_builds(visual_versions=["10"],
+                                   archs=["x86", "x86_64"],
+                                   visual_runtimes=["MDd"],
                                    dll_with_static_runtime=True,
                                    vs10_x86_64_enabled=False,
-                                   build_types=["Debug"])
+                                   build_types=["Debug"],
+                                   common_options={"libpng:shared": [True, False]})
         expected = [
             ({'compiler.runtime': 'MDd', 'arch': 'x86', 'build_type': 'Debug', 'compiler': 'Visual Studio',
               'compiler.version': '10'},
@@ -399,11 +487,13 @@ class GeneratorsTest(unittest.TestCase):
 
         self.assertEquals([tuple(a) for a in builds], expected)
 
-        builds = get_visual_builds(visual_versions=["10"], archs=["x86", "x86_64"], visual_runtimes=["MTd"],
-                                   shared_option_name="libpng:shared",
+        builds = get_visual_builds(visual_versions=["10"],
+                                   archs=["x86", "x86_64"],
+                                   visual_runtimes=["MTd"],
                                    dll_with_static_runtime=False,
                                    vs10_x86_64_enabled=False,
-                                   build_types=["Debug"])
+                                   build_types=["Debug"],
+                                   common_options={"libpng:shared": [True, False]})
         expected = [
             ({'compiler': 'Visual Studio', 'compiler.runtime': 'MTd', 'compiler.version': '10', 'arch': 'x86',
               'build_type': 'Debug'},
@@ -413,11 +503,13 @@ class GeneratorsTest(unittest.TestCase):
 
         #############
 
-        builds = get_visual_builds(visual_versions=["10", "14"], archs=["x86_64"], visual_runtimes=["MD", "MT"],
-                                   shared_option_name=None,
+        builds = get_visual_builds(visual_versions=["10", "14"],
+                                   archs=["x86_64"],
+                                   visual_runtimes=["MD", "MT"],
                                    dll_with_static_runtime=False,
                                    vs10_x86_64_enabled=True,
-                                   build_types=["Release"])
+                                   build_types=["Release"],
+                                   common_options={})
 
         expected = [
             ({'arch': 'x86_64', 'build_type': 'Release', 'compiler': 'Visual Studio', 'compiler.version': '10',
@@ -431,11 +523,13 @@ class GeneratorsTest(unittest.TestCase):
 
         self.assertEquals([tuple(a) for a in builds], expected)
 
-        builds = get_visual_builds(visual_versions=["10"], archs=["x86", "x86_64"], visual_runtimes=["MD"],
-                                   shared_option_name="libpng:shared",
+        builds = get_visual_builds(visual_versions=["10"],
+                                   archs=["x86", "x86_64"],
+                                   visual_runtimes=["MD"],
                                    dll_with_static_runtime=True,
                                    vs10_x86_64_enabled=True,
-                                   build_types=["Release"])
+                                   build_types=["Release"],
+                                   common_options={"libpng:shared": [True, False]})
 
         expected = [
             ({'compiler.runtime': 'MD', 'arch': 'x86', 'build_type': 'Release', 'compiler': 'Visual Studio',
@@ -453,11 +547,13 @@ class GeneratorsTest(unittest.TestCase):
 
         self.assertEquals([tuple(a) for a in builds], expected)
 
-        builds = get_visual_builds(visual_versions=["10"], archs=["x86", "x86_64"], visual_runtimes=["MD"],
-                                   shared_option_name="libpng:shared",
+        builds = get_visual_builds(visual_versions=["10"],
+                                   archs=["x86", "x86_64"],
+                                   visual_runtimes=["MD"],
                                    dll_with_static_runtime=True,
                                    vs10_x86_64_enabled=False,
-                                   build_types=["Release"])
+                                   build_types=["Release"],
+                                   common_options={"libpng:shared": [True, False]})
         expected = [
             ({'compiler.runtime': 'MD', 'arch': 'x86', 'build_type': 'Release', 'compiler': 'Visual Studio',
               'compiler.version': '10'},
@@ -468,14 +564,41 @@ class GeneratorsTest(unittest.TestCase):
 
         self.assertEquals([tuple(a) for a in builds], expected)
 
-        builds = get_visual_builds(visual_versions=["10"], archs=["x86", "x86_64"], visual_runtimes=["MT"],
-                                   shared_option_name="libpng:shared",
+        builds = get_visual_builds(visual_versions=["10"],
+                                   archs=["x86", "x86_64"],
+                                   visual_runtimes=["MT"],
                                    dll_with_static_runtime=False,
                                    vs10_x86_64_enabled=False,
-                                   build_types=["Release"])
+                                   build_types=["Release"],
+                                   common_options={"libpng:shared": [True, False]})
         expected = [
             ({'compiler': 'Visual Studio', 'compiler.runtime': 'MT', 'compiler.version': '10', 'arch': 'x86',
               'build_type': 'Release'},
              {'libpng:shared': False}, {}, {}, None)]
 
         self.assertEquals([tuple(a) for a in builds], expected)
+
+    def options_test(self):
+        options = {"shared": [True, False], "opt": [True, False]}
+        combinations = _combine_common_options(options)
+        self.assertEquals(combinations, [(("shared", True), ("opt", True)),
+                                         (("shared", True), ("opt", False)),
+                                         (("shared", False), ("opt", True)),
+                                         (("shared", False), ("opt", False))])
+
+        options = {"shared": [True, False]}
+        combinations = _combine_common_options(options)
+        self.assertEquals(combinations, [(("shared", True)), (("shared", False))])
+
+
+        expanded_option1 = (("shared", True), ("opt", True))
+        option_dict = _option_dict_from_combination(expanded_option1)
+        self.assertEqual(option_dict, {"shared": True, "opt": True})
+
+        expanded_option2 = (("shared", True), ("opt", False))
+        option_dict = _option_dict_from_combination(expanded_option2)
+        self.assertEqual(option_dict, {"shared": True, "opt": False})
+
+        single_expanded_option = (("shared", True))
+        option_dict = _option_dict_from_combination(single_expanded_option)
+        self.assertEqual(option_dict, {"shared": True})


### PR DESCRIPTION
Added `comon_options` to `add_common_builds()` supporting a full options dictionary like `common_options={"CMAKE_GNUtoMS":[True, False], "my_option":["value1", "value2"]}`.

Then, the add_common_builds() generates all the possible options combinations and adds them to the matrix.

Still missing docs in the readme 😝 