### PR TITLE
Support windows branch detect without grep

### DIFF
--- a/conan/ci_manager.py
+++ b/conan/ci_manager.py
@@ -92,7 +92,11 @@ class GenericManager(object):
 
     def get_branch(self):
         try:
-            msg = subprocess.check_output("git branch | grep \*", shell=True).decode().strip()
+            if platform.system() == "Windows":
+                search_string = 'find "\*"'
+            else:
+                search_string = 'grep \*'
+            msg = subprocess.check_output("git branch | %s " % search_string, shell=True).decode().strip()
             if " (HEAD detached" not in msg:
                 return msg
             return None

--- a/conan/ci_manager.py
+++ b/conan/ci_manager.py
@@ -1,6 +1,7 @@
 import re
 import os
 import subprocess
+import platform
 
 from conan.printer import print_message
 


### PR DESCRIPTION
Was getting these at runtime and flooding during unit tests.
```
'grep' is not recognized as an internal or external command,
operable program or batch file.
E'grep' is not recognized as an internal or external command,
```