### PR TITLE
Open requirements.txt as a text file to prevent error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ from codecs import open
 
 def get_requires(filename):
     requirements = []
-    with open(filename) as req_file:
+    with open(filename, 'rt') as req_file:
         for line in req_file.read().splitlines():
             if not line.strip().startswith("#"):
                 requirements.append(line)


### PR DESCRIPTION
"startswith first arg must be bytes or a tuple of bytes, not str"