### PR TITLE
add passing pip index url's to containers via environment variables

### DIFF
--- a/cpt/packager.py
+++ b/cpt/packager.py
@@ -165,15 +165,15 @@ class ConanMultiPackager(object):
 
         self.sudo_docker_command = ""
         if "CONAN_DOCKER_USE_SUDO" in os.environ:
-            self.sudo_docker_command = "sudo" if get_bool_from_env("CONAN_DOCKER_USE_SUDO") else ""
+            self.sudo_docker_command = "sudo -E" if get_bool_from_env("CONAN_DOCKER_USE_SUDO") else ""
         elif platform.system() != "Windows":
-            self.sudo_docker_command = "sudo"
+            self.sudo_docker_command = "sudo -E"
 
         self.sudo_pip_command = ""
         if "CONAN_PIP_USE_SUDO" in os.environ:
-            self.sudo_pip_command = "sudo" if get_bool_from_env("CONAN_PIP_USE_SUDO") else ""
+            self.sudo_pip_command = "sudo -E" if get_bool_from_env("CONAN_PIP_USE_SUDO") else ""
         elif platform.system() != "Windows":
-            self.sudo_pip_command = "sudo"
+            self.sudo_pip_command = "sudo -E"
 
         self.exclude_vcvars_precommand = (exclude_vcvars_precommand or
                                           os.getenv("CONAN_EXCLUDE_VCVARS_PRECOMMAND", False))

--- a/cpt/runner.py
+++ b/cpt/runner.py
@@ -109,13 +109,21 @@ class DockerCreateRunner(object):
         return command
 
     def run(self, pull_image=True, docker_entry_script=None):
+
+        envs = self.get_env_vars()
+        env_vars_text = " ".join(['-e %s="%s"' % (key, value)
+                                 for key, value in envs.items() if value])
+
+        env_vars_text += " -e PIP_INDEX_URL -e PIP_EXTRA_INDEX_URL"
+
         if pull_image:
             self.pull_image()
             if not self._docker_image_skip_update and not self._always_update_conan_in_docker:
                 # Update the downloaded image
                 with self.printer.foldable_output("update conan"):
-                    command = '%s docker run --name conan_runner ' \
+                    command = '%s docker run %s --name conan_runner ' \
                               ' %s /bin/sh -c "%s"' % (self._sudo_docker_command,
+                                                       env_vars_text,
                                                        self._docker_image,
                                                        self._pip_update_conan_command())
                     ret = self._runner(command)


### PR DESCRIPTION
This enables users to install custom pip packages from private PIP registries into the containers before running the build.  Users can do custom `pip install` commands currently via the `CONAN_DOCKER_ENTRY_SCRIPT`, but they also have to append with `--index-url=...` or `--extra-index-url=...`.  With this PR, if the corresponding environment variables are set on the host OS, they will be automatically passed to the container, and used by PIP.  The `-E` parameter on the `sudo` command brings current users environment variables into the `sudo` context so they can be passed in the docker command. 