### PR TITLE
parameterize the shell and home vars for future extensibility

### DIFF
--- a/cpt/packager.py
+++ b/cpt/packager.py
@@ -175,6 +175,9 @@ class ConanMultiPackager(object):
         elif platform.system() != "Windows":
             self.sudo_pip_command = "sudo"
 
+        self.docker_shell = "/bin/sh -c"
+        self.docker_conan_home = "/home/conan"
+
         self.exclude_vcvars_precommand = (exclude_vcvars_precommand or
                                           os.getenv("CONAN_EXCLUDE_VCVARS_PRECOMMAND", False))
         self._docker_image_skip_update = (docker_image_skip_update or
@@ -413,7 +416,9 @@ class ConanMultiPackager(object):
                                        build_policy=self.build_policy,
                                        always_update_conan_in_docker=self._update_conan_in_docker,
                                        upload=self._upload_enabled(),
-                                       runner=self.runner)
+                                       runner=self.runner,
+                                       docker_shell=self.docker_shell,
+                                       docker_conan_home=self.docker_conan_home)
 
                 r.run(pull_image=not pulled_docker_images[docker_image],
                       docker_entry_script=self.docker_entry_script)

--- a/cpt/runner.py
+++ b/cpt/runner.py
@@ -73,7 +73,8 @@ class DockerCreateRunner(object):
                  sudo_pip_command=True,
                  docker_image_skip_update=False, build_policy=None,
                  always_update_conan_in_docker=False,
-                 upload=False, runner=None):
+                 upload=False, runner=None,
+                 docker_shell=None, docker_conan_home=None):
 
         self.printer = Printer()
         self._args = args
@@ -89,6 +90,8 @@ class DockerCreateRunner(object):
         self._profile_text = profile_text
         self._base_profile_text = base_profile_text
         self._base_profile_name = base_profile_name
+        self._docker_shell = docker_shell
+        self._docker_conan_home = docker_conan_home
         self._runner = PrintRunner(runner, self.printer)
 
     def _pip_update_conan_command(self):
@@ -143,11 +146,15 @@ class DockerCreateRunner(object):
             update_command = self._pip_update_conan_command() + " && "
         else:
             update_command = ""
-        command = ("%s docker run --rm -v%s:/home/conan/project %s %s /bin/sh "
-                   "-c \"cd project && "
-                   "%s run_create_in_docker \"" % (self._sudo_docker_command, os.getcwd(),
-                                                   env_vars_text, self._docker_image,
-                                                   update_command))
+        command = ('%s docker run --rm -v %s:%s/project %s %s %s '
+                   '"cd project && '
+                   '%s run_create_in_docker "' % (self._sudo_docker_command,
+                                                  os.getcwd(),
+                                                  self._docker_conan_home,
+                                                  env_vars_text,
+                                                  self._docker_image,
+                                                  self._docker_shell,
+                                                  update_command))
 
         # Push entry command before to build
         if docker_entry_script:


### PR DESCRIPTION
in preparation for docker for windows, this brings the hard-coded shell and home directories out into packager.py, where they can be set dynamically in the future based on environment factors alongside other similar variables. 