### PR TITLE
add environment variable to control docker pull command

### DIFF
--- a/README.md
+++ b/README.md
@@ -911,6 +911,7 @@ Using **CONAN_CLANG_VERSIONS** env variable in Travis ci or Appveyor:
 - **archs**: List containing specific architectures to build for. Default ["x86", "x86_64"]
 - **use_docker**: Use docker for package creation in Linux systems.
 - **docker_image_skip_update**: If defined, it will skip the initialization update of "conan package tools" and "conan" in the docker image. By default is False.
+- **docker_image_skip_pull**: If defined, it will skip the "docker pull" command, enabling a local image to be used, and without being overwritten.
 - **always_update_conan_in_docker**: If True, "conan package tools" and "conan" will be installed and upgraded in the docker image in every build execution.
   and the container won't be commited with the modifications.
 - **docker_entry_script**: Command to be executed before to build when running Docker.
@@ -1030,7 +1031,8 @@ This is especially useful for CI integration.
 - **CONAN_TOTAL_PAGES**: Total number of pages
 - **CONAN_DOCKER_IMAGE**: If defined and docker is being used, it will use this dockerimage instead of the default images, e.g. "lasote/conangcc63"
 - **CONAN_DOCKER_IMAGE_SKIP_UPDATE**: If defined, it will skip the initialization update of "conan package tools" and "conan" in the docker image. By default is False.
-- **CONAN_ALWAYS_UPDATE_CONAN_DOCKER**: If defined, "conan package tools" and "conan" will be installed and upgraded in the docker image in every build execution 
+- **CONAN_DOCKER_IMAGE_SKIP_PULL**: If defined, it will skip the "docker pull" command, enabling a local image to be used, and without being overwritten.
+- **CONAN_ALWAYS_UPDATE_CONAN_DOCKER**: If defined, "conan package tools" and "conan" will be installed and upgraded in the docker image in every build execution
   and the container won't be commited with the modifications.
 - **CONAN_DOCKER_32_IMAGES**: If defined, and the current build is arch="x86" the docker image name will be appended with "-i386". e.j: "lasote/conangcc63-i386"
 - **CONAN_STABLE_BRANCH_PATTERN**: Regular expression, if current git branch matches this pattern, the packages will be uploaded to *CONAN_STABLE_CHANNEL* channel. Default "master". E.j: "release/*"

--- a/cpt/packager.py
+++ b/cpt/packager.py
@@ -78,6 +78,7 @@ class ConanMultiPackager(object):
                  allow_gcc_minors=False,
                  exclude_vcvars_precommand=False,
                  docker_image_skip_update=False,
+                 docker_image_skip_pull=False,
                  docker_entry_script=None,
                  docker_32_images=None,
                  build_policy=None,
@@ -179,6 +180,9 @@ class ConanMultiPackager(object):
                                           os.getenv("CONAN_EXCLUDE_VCVARS_PRECOMMAND", False))
         self._docker_image_skip_update = (docker_image_skip_update or
                                           os.getenv("CONAN_DOCKER_IMAGE_SKIP_UPDATE", False))
+        self._docker_image_skip_pull = (docker_image_skip_pull or
+                                        os.getenv("CONAN_DOCKER_IMAGE_SKIP_PULL", False))
+
         self.runner = runner or os.system
         self.output_runner = ConanOutputRunner()
         self.args = " ".join(args) if args else " ".join(sys.argv[1:])
@@ -410,6 +414,7 @@ class ConanMultiPackager(object):
                                        sudo_docker_command=self.sudo_docker_command,
                                        sudo_pip_command=self.sudo_pip_command,
                                        docker_image_skip_update=self._docker_image_skip_update,
+                                       docker_image_skip_pull=self._docker_image_skip_pull,
                                        build_policy=self.build_policy,
                                        always_update_conan_in_docker=self._update_conan_in_docker,
                                        upload=self._upload_enabled(),

--- a/cpt/runner.py
+++ b/cpt/runner.py
@@ -72,6 +72,7 @@ class DockerCreateRunner(object):
                  args=None, conan_pip_package=None, docker_image=None, sudo_docker_command=None,
                  sudo_pip_command=True,
                  docker_image_skip_update=False, build_policy=None,
+                 docker_image_skip_pull=False,
                  always_update_conan_in_docker=False,
                  upload=False, runner=None):
 
@@ -84,6 +85,7 @@ class DockerCreateRunner(object):
         self._docker_image = docker_image
         self._always_update_conan_in_docker = always_update_conan_in_docker
         self._docker_image_skip_update = docker_image_skip_update
+        self._docker_image_skip_pull = docker_image_skip_pull
         self._sudo_docker_command = sudo_docker_command or ""
         self._sudo_pip_command = sudo_pip_command
         self._profile_text = profile_text
@@ -110,7 +112,8 @@ class DockerCreateRunner(object):
 
     def run(self, pull_image=True, docker_entry_script=None):
         if pull_image:
-            self.pull_image()
+            if not self._docker_image_skip_pull:
+                self.pull_image()
             if not self._docker_image_skip_update and not self._always_update_conan_in_docker:
                 # Update the downloaded image
                 with self.printer.foldable_output("update conan"):


### PR DESCRIPTION
This feature makes it possible to run a local build with CPT against a local docker container which has not yet been uploaded to a remote for which it is tagged, or which has been modified locally and it is not desirable to update the image on the remote yet.   Also, it was needed when having technical problems with the docker registry with which the images are associated.  