### PR TITLE
get env vars set from Bamboo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ htmlcov/
 .coverage
 .coverage.*
 .cache
+.noseids
 nosetests.xml
 coverage.xml
 *,cover

--- a/cpt/ci_manager.py
+++ b/cpt/ci_manager.py
@@ -154,6 +154,13 @@ class BambooManager(GenericManager):
         super(BambooManager, self).__init__(printer)
         self.printer.print_message("CI detected: Bamboo")
 
+        for var in list(os.environ.keys()):
+            result = re.match('\Abamboo\.(.*)', var)
+            if result != None:
+                self.printer.print_message("de-bambooized env var : %s " % result.group(1))
+                os.environ[result.group(1)] = os.environ[var]
+
+
     def get_branch(self):
         return os.getenv("bamboo_planRepository_branch", None)
 

--- a/cpt/test/unit/ci_manager_test.py
+++ b/cpt/test/unit/ci_manager_test.py
@@ -136,3 +136,14 @@ class CIManagerTest(unittest.TestCase):
                                        }):
             manager = CIManager(self.printer)
             self.assertRaises(Exception, manager.get_commit_build_policy)
+
+    def test_bamboo_env_vars(self):
+        self.assertIsNone(os.getenv('CONAN_LOGIN_USERNAME'))
+
+        with tools.environment_append({"bamboo_buildNumber": "xx",
+                                       "bamboo_planRepository_branch": "mybranch",
+                                       "bamboo.CONAN_LOGIN_USERNAME": "bamboo"}):
+            manager = CIManager(self.printer)
+            self.assertEquals(manager.get_branch(), "mybranch") # checks that manager is Bamboo 
+
+            self.assertEquals(os.getenv('CONAN_LOGIN_USERNAME'), "bamboo")


### PR DESCRIPTION
The packager uses multiples env vars to setup externally different security aspects or configurations.

From within Bamboo (Atlassian CI) one can define globally available env vars but Bamboo adds a "bamboo." prefix to all env vars.

The PR proposed to add a get_value_from_env tool that mimics os.getenv but also tests for bamboo's prefixed vars.