### PR TITLE
Correct de-bambooification of env vars #231

### DIFF
--- a/cpt/ci_manager.py
+++ b/cpt/ci_manager.py
@@ -155,9 +155,9 @@ class BambooManager(GenericManager):
         self.printer.print_message("CI detected: Bamboo")
 
         for var in list(os.environ.keys()):
-            result = re.match('\Abamboo\.(.*)', var)
-            if result != None:
-                self.printer.print_message("de-bambooized env var : %s " % result.group(1))
+            result = re.match('\Abamboo_(CONAN.*)', var)
+            if result != None and os.getenv(result.group(1), None) == None:
+                self.printer.print_message("de-bambooized CONAN env var : %s " % result.group(1))
                 os.environ[result.group(1)] = os.environ[var]
 
 

--- a/cpt/test/unit/ci_manager_test.py
+++ b/cpt/test/unit/ci_manager_test.py
@@ -142,8 +142,11 @@ class CIManagerTest(unittest.TestCase):
 
         with tools.environment_append({"bamboo_buildNumber": "xx",
                                        "bamboo_planRepository_branch": "mybranch",
-                                       "bamboo.CONAN_LOGIN_USERNAME": "bamboo"}):
+                                       "bamboo_CONAN_LOGIN_USERNAME": "bamboo",
+                                       "bamboo_CONAN_USER_VAR": "bamboo",
+                                       "CONAN_USER_VAR": "foobar"}):
             manager = CIManager(self.printer)
             self.assertEquals(manager.get_branch(), "mybranch") # checks that manager is Bamboo 
 
             self.assertEquals(os.getenv('CONAN_LOGIN_USERNAME'), "bamboo")
+            self.assertEquals(os.getenv('CONAN_USER_VAR'), "foobar")


### PR DESCRIPTION
Remove the `bamboo_` part of env vars matching `bamboo_CONAN.*`
this hopefully corrects #231