### PR TITLE
Implement two helper methods for filtering or updating existing builds

### DIFF
--- a/cpt/packager.py
+++ b/cpt/packager.py
@@ -367,6 +367,32 @@ class ConanMultiPackager(object):
         reference = reference or self.reference
         self._builds.append(BuildConf(settings, options, env_vars, build_requires, reference))
 
+    def remove_build_if(self, predicate):
+        filtered_builds = []
+        for build in self.items:
+            if predicate(build):
+                filtered_builds.append(build)
+
+        self._builds = filtered_builds
+
+    def update_build_if(self, predicate, new_settings=None, new_options=None, new_env_vars=None,
+                        new_build_requires=None, new_reference=None):
+        updated_builds = []
+        for build in self.items:
+            if predicate(build):
+                if new_settings:
+                    build.settings.update(new_settings)
+                if new_options:
+                    build.options.update(new_options)
+                if new_build_requires:
+                    build.build_requires.update(new_build_requires)
+                if new_env_vars:
+                    build.env_vars.update(new_env_vars)
+                if new_reference:
+                    build.reference = new_reference
+            updated_builds.append(build)
+        self._builds = updated_builds
+
     def run(self, base_profile_name=None):
         env_vars = self.auth_manager.env_vars()
         env_vars.update(self.remotes_manager.env_vars())

--- a/cpt/test/unit/packager_test.py
+++ b/cpt/test/unit/packager_test.py
@@ -41,6 +41,45 @@ class AppTest(unittest.TestCase):
                           {"option%d" % number: "value%d" % number,
                            "option%d" % number: "value%d" % number})
 
+    def test_remove_build_if(self):
+        self.packager.add({"arch": "x86", "build_type": "Release", "compiler": "gcc", "compiler.version": "6"})
+        self.packager.add({"arch": "x86", "build_type": "Debug", "compiler": "gcc", "compiler.version": "6"})
+        self.packager.add({"arch": "x86_64", "build_type": "Release", "compiler": "gcc", "compiler.version": "7"})
+        self.packager.add({"arch": "x86_64", "build_type": "Debug", "compiler": "gcc", "compiler.version": "7"})
+
+        self.packager.remove_build_if(lambda build: build.settings["compiler.version"] == "6")
+
+        packager_expected = ConanMultiPackager(["--build missing", "-r conan.io"],
+                                               "lasote", "mychannel",
+                                               runner=self.runner,
+                                               conan_api=self.conan_api,
+                                               reference="lib/1.0",
+                                               ci_manager=self.ci_manager)
+
+        packager_expected.add({"arch": "x86", "build_type": "Release", "compiler": "gcc", "compiler.version": "6"})
+        packager_expected.add({"arch": "x86", "build_type": "Debug", "compiler": "gcc", "compiler.version": "6"})
+
+        self.assertEqual([tuple(a) for a in self.packager.items], packager_expected.items)
+
+    def test_update_build_if(self):
+        self.packager.add({"os": "Windows"})
+        self.packager.add({"os": "Linux"})
+
+        self.packager.update_build_if(lambda build: build.settings["os"] == "Windows",
+                                      new_build_requires={"*": "7zip_installer/0.1.0@conan/stable"})
+
+        packager_expected = ConanMultiPackager(["--build missing", "-r conan.io"],
+                                               "lasote", "mychannel",
+                                               runner=self.runner,
+                                               conan_api=self.conan_api,
+                                               reference="lib/1.0",
+                                               ci_manager=self.ci_manager)
+
+        packager_expected.add({"os": "Windows"}, {}, {}, {"*": "7zip_installer/0.1.0@conan/stable"})
+        packager_expected.add({"os": "Linux"})
+
+        self.assertEqual([tuple(a) for a in self.packager.items], packager_expected.items)
+
     def test_full_profile(self):
         self.packager.add({"os": "Windows", "compiler": "gcc"},
                           {"option1": "One"},

--- a/cpt/test/unit/packager_test.py
+++ b/cpt/test/unit/packager_test.py
@@ -66,7 +66,7 @@ class AppTest(unittest.TestCase):
         self.packager.add({"os": "Linux"})
 
         self.packager.update_build_if(lambda build: build.settings["os"] == "Windows",
-                                      new_build_requires={"*": "7zip_installer/0.1.0@conan/stable"})
+                                      new_build_requires={"*": ["7zip_installer/0.1.0@conan/stable"]})
 
         packager_expected = ConanMultiPackager(["--build missing", "-r conan.io"],
                                                "lasote", "mychannel",
@@ -75,7 +75,7 @@ class AppTest(unittest.TestCase):
                                                reference="lib/1.0",
                                                ci_manager=self.ci_manager)
 
-        packager_expected.add({"os": "Windows"}, {}, {}, {"*": "7zip_installer/0.1.0@conan/stable"})
+        packager_expected.add({"os": "Windows"}, {}, {}, {"*": ["7zip_installer/0.1.0@conan/stable"]})
         packager_expected.add({"os": "Linux"})
 
         self.assertEqual([tuple(a) for a in self.packager.items], packager_expected.items)


### PR DESCRIPTION
Changelog: Feature: New `remove_build_if` and `update_build_if` helper methods to filter/update existing builds.

Original feature request for remove_if here: 
https://github.com/conan-io/conan-package-tools/issues/249

Also included related feature `update_build_if` which provides a more concise syntax than the raw for loop in the readme for a few common operations like conditionally adding `build_requires` or changing options. 