### PR TITLE
Invalid configuration implemented

### DIFF
--- a/cpt/packager.py
+++ b/cpt/packager.py
@@ -15,14 +15,13 @@ from cpt import NEWEST_CONAN_SUPPORTED
 from cpt.auth import AuthManager
 from cpt.builds_generator import BuildConf, BuildGenerator
 from cpt.ci_manager import CIManager
+from cpt.config import ConfigManager
 from cpt.printer import Printer
 from cpt.profiles import get_profiles, save_profile_to_tmp
 from cpt.remotes import RemotesManager
-from cpt.tools import get_bool_from_env, split_colon_env
-from cpt.builds_generator import BuildConf, BuildGenerator
-from cpt.config import ConfigManager
 from cpt.runner import CreateRunner, DockerCreateRunner
 from cpt.tools import get_bool_from_env
+from cpt.tools import split_colon_env
 from cpt.uploader import Uploader
 
 

--- a/cpt/printer.py
+++ b/cpt/printer.py
@@ -108,8 +108,8 @@ class Printer(object):
 
         if len(table):
             self.printer(tabulate(table, headers=list(compiler_headers) + list(option_headers),
-                             # showindex=True,
-                             tablefmt='psql'))
+                                  # showindex=True,
+                                  tablefmt='psql'))
             self.printer("\n")
         else:
             self.printer("There are no jobs!\n")

--- a/cpt/test/test_client/invalid_config_checks_test.py
+++ b/cpt/test/test_client/invalid_config_checks_test.py
@@ -32,5 +32,4 @@ class Pkg(ConanFile):
             mulitpackager.add({"arch": "x86"}, {})
             mulitpackager.run()
             self.assertIn("Uploading package 1/1", tc.out)
-            self.assertIn(">> Skipped configuration by the recipe: lib/1.0@user/testing: "
-                          "Invalid configuration: This library doesn't support x86", tc.out)
+            self.assertIn("Invalid configuration: This library doesn't support x86", tc.out)

--- a/cpt/test/test_client/invalid_config_checks_test.py
+++ b/cpt/test/test_client/invalid_config_checks_test.py
@@ -1,0 +1,36 @@
+import unittest
+
+from conans.client.tools import environment_append
+from conans.test.utils.tools import TestClient, TestServer
+
+from cpt.test.test_client.tools import get_patched_multipackager
+
+
+class InvalidConfigTest(unittest.TestCase):
+
+    conanfile = """from conans import ConanFile
+from conans.errors import ConanInvalidConfiguration
+class Pkg(ConanFile):
+    name = "lib"
+    version = "1.0"
+    settings = "arch"
+
+    def configure(self):
+        if self.settings.arch == "x86":
+            raise ConanInvalidConfiguration("This library doesn't support x86")
+"""
+
+    def test_invalid_configuration_skipped_but_warned(self):
+
+        ts = TestServer(users={"user": "password"})
+        tc = TestClient(servers={"default": ts}, users={"default": [("user", "password")]})
+        tc.save({"conanfile.py": self.conanfile})
+        with environment_append({"CONAN_UPLOAD": ts.fake_url, "CONAN_LOGIN_USERNAME": "user",
+                                 "CONAN_PASSWORD": "password", "CONAN_USERNAME": "user"}):
+            mulitpackager = get_patched_multipackager(tc, exclude_vcvars_precommand=True)
+            mulitpackager.add({"arch": "x86_64"}, {})
+            mulitpackager.add({"arch": "x86"}, {})
+            mulitpackager.run()
+            self.assertIn("Uploading package 1/1", tc.out)
+            self.assertIn(">> Skipped configuration by the recipe: lib/1.0@user/testing: "
+                          "Invalid configuration: This library doesn't support x86", tc.out)


### PR DESCRIPTION
Changelog: Feature: Added support for [ConanInvalidConfiguration](https://docs.conan.io/en/latest/reference/conanfile/methods.html?#invalid-configuration) so when a recipe declares that a configuration is not supported, CPT will print a warning but will skip that configuration (without raising any error).

Closes #146