### PR TITLE
#506 Fix formatted upload url

### DIFF
--- a/cpt/remotes.py
+++ b/cpt/remotes.py
@@ -28,7 +28,7 @@ class RemotesManager(object):
         if remotes_input:
             if isinstance(remotes_input, string_types):
                 for n, r in enumerate(remotes_input.split(",")):
-                    self._remotes.append(Remote(r.strip(), True, "remote%s" % n))
+                    self._remotes.append(self._get_remote_from_str(r, "CONAN_REMOTES", "remote%s" % n))
             elif hasattr(remotes_input, '__iter__'):
                 for n, r in enumerate(remotes_input):
                     if isinstance(r, string_types):
@@ -46,7 +46,7 @@ class RemotesManager(object):
 
         if upload_input:
             if isinstance(upload_input, string_types):
-                self._upload = Remote(upload_input, True, "upload_repo")
+                self._upload = self._get_remote_from_str(upload_input, "CONAN_UPLOAD", "upload_repo")
             elif hasattr(upload_input, '__iter__'):
                 if len(upload_input) != 3:
                     raise Exception("Incorrect 'upload' argument, check README")

--- a/cpt/test/integration/remotes_test.py
+++ b/cpt/test/integration/remotes_test.py
@@ -1,3 +1,4 @@
+from conans.client.remote_registry import Remote
 from cpt.printer import Printer
 from cpt.remotes import RemotesManager
 from cpt.test.integration.base import BaseTest
@@ -16,13 +17,21 @@ class RemotesTest(BaseTest):
         remotes = self.api.remote_list()
         self.assertIsNotNone(manager._get_remote_by_name(remotes, "upload_repo"))
 
+        expected_remote = [Remote(name='upload_repo', url='url_different', verify_ssl=True)]
+        self.assertEqual(expected_remote, remotes)
+
+        manager.add_remotes_to_conan()
+
+        remotes = self.api.remote_list()
+        self.assertEquals(len(self.api.remote_list()), 1)
+
+        expected_remote = [Remote(name='upload_repo', url='url1', verify_ssl=True)]
+        self.assertEqual(expected_remote, remotes)
+
         manager.add_remotes_to_conan()
 
         self.assertEquals(len(self.api.remote_list()), 1)
-
-        manager.add_remotes_to_conan()
-
-        self.assertEquals(len(self.api.remote_list()), 1)
+        self.assertEqual(expected_remote, remotes)
 
     def test_duplicated_remotes_with_same_url(self):
 
@@ -35,5 +44,9 @@ class RemotesTest(BaseTest):
         remotes = self.api.remote_list()
         self.assertIsNotNone(manager._get_remote_by_name(remotes, "upload_repo"))
 
+        expected_remote = [Remote(name='upload_repo', url='url1', verify_ssl=True)]
+        self.assertEqual(expected_remote, remotes)
+
         manager.add_remotes_to_conan()
         self.assertEquals(len(self.api.remote_list()), 1)
+        self.assertEqual(expected_remote, remotes)


### PR DESCRIPTION
Hi!

CPT doesn't support extra data when receiving upload URL by parameters:

```
ConanMultiPackager(upload="https://api.bintray.com/conan/bincrafters/public-conan@True@bincrafters")
```

The result will be:

```
$ conan remote list
upload_repo: https://api.bintray.com/conan/bincrafters/public-conan@True@bincrafters [Verify SSL: True]
conan-center: https://conan.bintray.com [Verify SSL: True]
```

This PR fix this situation, splitting the string and creating the correct name for remote.

Conan Version: 1.9.2
CPT Version: 0.20.0

Related issue: https://github.com/bincrafters/community/issues/506