### PR TITLE
Skip image update by default

### DIFF
--- a/cpt/packager.py
+++ b/cpt/packager.py
@@ -231,7 +231,7 @@ class ConanMultiPackager(object):
         self.exclude_vcvars_precommand = (exclude_vcvars_precommand or
                                           os.getenv("CONAN_EXCLUDE_VCVARS_PRECOMMAND", False))
         self._docker_image_skip_update = (docker_image_skip_update or
-                                          os.getenv("CONAN_DOCKER_IMAGE_SKIP_UPDATE", False))
+                                          os.getenv("CONAN_DOCKER_IMAGE_SKIP_UPDATE", True))
         self._docker_image_skip_pull = (docker_image_skip_pull or
                                         os.getenv("CONAN_DOCKER_IMAGE_SKIP_PULL", False))
 


### PR DESCRIPTION
Hi!

This PR is related to https://github.com/conan-io/conan-docker-tools/issues/87

The idea is providing only images with all latest version of CPT and Conan. This approach save some time by CI job.

/cc @SSE4 @lasote 