### PR TITLE
Force pyOpenSSL version range

### DIFF
--- a/cpt/requirements.txt
+++ b/cpt/requirements.txt
@@ -3,3 +3,4 @@ six>=1.10.0
 requests[security]
 conan>=1.7.0, <1.13.0
 tabulate==0.8.2
+pyOpenSSL>=16.0.0, <19.0.0


### PR DESCRIPTION
- requests[security] requires pyOpenSSL 18.0.0, however,
  Conan requires < 18.0.0. Keeping the same version range
  in both project could help us.

related issue: https://github.com/conan-io/conan/pull/4333