### PR TITLE
#328 Remove pyOpenSSL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ cache: pip
 language: python
 python:
     - 2.7
-    - 3.6
+    - 3.7
 os: linux
 dist: xenial
 
@@ -11,6 +11,9 @@ matrix:
         - language: generic
           os: osx
           env: PYVER=py27
+        - language: generic
+          os: osx
+          env: PYVER=py37
 
 # command to install dependencies
 install:

--- a/cpt/requirements.txt
+++ b/cpt/requirements.txt
@@ -3,4 +3,3 @@ six>=1.10.0
 requests[security]
 conan>=1.7.0, <1.13.0
 tabulate==0.8.2
-pyOpenSSL>=16.0.0, <19.0.0


### PR DESCRIPTION
Hi!

I've removed pyOpenSSL and idna from requirements because of #328 and https://github.com/conan-io/conan/issues/4331.

Both `Conan` and `requests[security]` are using pyOpenSSL and idna, so it will be added implicit, besides we don't use ssl or idna directly on CPT.