### PR TITLE
Fix CPT tests

### DIFF
--- a/cpt/test/test_client/upload_checks_test.py
+++ b/cpt/test/test_client/upload_checks_test.py
@@ -67,7 +67,8 @@ class Pkg(ConanFile):
 
         with environment_append({"CONAN_UPLOAD": ts.fake_url, "CONAN_LOGIN_USERNAME": "user",
                                  "CONAN_PASSWORD": "password", "CONAN_USERNAME": "user",
-                                 "CONAN_CONFIG_URL": zip_path, "CONAN_UPLOAD_ONLY_WHEN_TAG": "1"}):
+                                 "CONAN_CONFIG_URL": zip_path, "CONAN_UPLOAD_ONLY_WHEN_TAG": "1",
+                                 "TRAVIS": "1"}):
 
             mp = get_patched_multipackager(tc, exclude_vcvars_precommand=True)
             mp.add_common_builds(shared_option_name=False)


### PR DESCRIPTION
The test `test_upload_when_tag_is_false` is validating when some messages are not present during CPT output, however, it does not simulate any CI manager, so CPT runs the real git commit commands. When the current commit is a tag, it will fail.

The idea to fix it is just forcing a CI service (Travis), where tag is checked by env var only.

related builds:
https://travis-ci.org/conan-io/conan-package-tools/builds/486820148
https://travis-ci.org/conan-io/conan-package-tools/builds/486820102