### PR TITLE
allow passing user-specified Docker args during create step

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,6 +430,17 @@ But if you prefer to use environment variables:
 
     export CONAN_PIP_INSTALL="bincrafters-package-tools==0.17.0,conan-promote=0.1.2"
 
+### Passing additional Docker parameters during build
+When running `conan create` step in Docker, you might want to run the container with additional parameters: for example, with `.conan/data` directory being mounted to parent system to avoid redownloading/rebuilding dependencies. For this you can use `docker_build_options` parameter
+
+    builder = ConanMultiPackager(
+      docker_build_options='--mount type=bind,source=$HOME/cached/conan-data,destination=/home/conan/.conan/data',
+      ...
+
+When run, this will translate to something like this:
+
+    sudo -E docker run ... --mount type=bind,source=$HOME/cached/conan-data,destination=/home/conan/.conan/data  conanio/gcc6 /bin/sh -c "cd project &&  run_create_in_docker"
+
 
 ### Installing custom Conan config
 
@@ -445,7 +456,7 @@ If you need to run `conan config install <url>` before to build there is the arg
         builder.add_common_builds()
         builder.run()
 
-But if are not interested to update your build.py script, it's possible to use environment variables instead:
+But if you are not interested to update your build.py script, it's possible to use environment variables instead:
 
     export CONAN_CONFIG_URL=https://github.com/bincrafters/conan-config.git
 
@@ -1008,6 +1019,7 @@ Using **CONAN_CLANG_VERSIONS** env variable in Travis ci or Appveyor:
 - **mingw_configurations**: Configurations for MinGW
 - **archs**: List containing specific architectures to build for. Default ["x86", "x86_64"]
 - **use_docker**: Use docker for package creation in Linux systems.
+- **docker_build_options**: Pass additional parameters for docker when running the create step.
 - **docker_conan_home**: Location where package source files will be copied to inside the Docker container
 - **docker_image_skip_update**: If defined, it will skip the initialization update of "conan package tools" and "conan" in the docker image. By default is False.
 - **docker_image_skip_pull**: If defined, it will skip the "docker pull" command, enabling a local image to be used, and without being overwritten.

--- a/README.md
+++ b/README.md
@@ -431,10 +431,10 @@ But if you prefer to use environment variables:
     export CONAN_PIP_INSTALL="bincrafters-package-tools==0.17.0,conan-promote=0.1.2"
 
 ### Passing additional Docker parameters during build
-When running `conan create` step in Docker, you might want to run the container with additional parameters: for example, with `.conan/data` directory being mounted to parent system to avoid redownloading/rebuilding dependencies. For this you can use `docker_build_options` parameter
+When running `conan create` step in Docker, you might want to run the container with additional parameters: for example, with `.conan/data` directory being mounted to parent system to avoid redownloading/rebuilding dependencies. For this you can use `docker_run_options` parameter
 
     builder = ConanMultiPackager(
-      docker_build_options='--mount type=bind,source=$HOME/cached/conan-data,destination=/home/conan/.conan/data',
+      docker_run_options='--mount type=bind,source=$HOME/cached/conan-data,destination=/home/conan/.conan/data',
       ...
 
 When run, this will translate to something like this:
@@ -1019,7 +1019,7 @@ Using **CONAN_CLANG_VERSIONS** env variable in Travis ci or Appveyor:
 - **mingw_configurations**: Configurations for MinGW
 - **archs**: List containing specific architectures to build for. Default ["x86", "x86_64"]
 - **use_docker**: Use docker for package creation in Linux systems.
-- **docker_build_options**: Pass additional parameters for docker when running the create step.
+- **docker_run_options**: Pass additional parameters for docker when running the create step.
 - **docker_conan_home**: Location where package source files will be copied to inside the Docker container
 - **docker_image_skip_update**: If defined, it will skip the initialization update of "conan package tools" and "conan" in the docker image. By default is False.
 - **docker_image_skip_pull**: If defined, it will skip the "docker pull" command, enabling a local image to be used, and without being overwritten.

--- a/README.md
+++ b/README.md
@@ -431,15 +431,15 @@ But if you prefer to use environment variables:
     export CONAN_PIP_INSTALL="bincrafters-package-tools==0.17.0,conan-promote=0.1.2"
 
 ### Passing additional Docker parameters during build
-When running `conan create` step in Docker, you might want to run the container with additional parameters: for example, with `.conan/data` directory being mounted to parent system to avoid redownloading/rebuilding dependencies. For this you can use `docker_run_options` parameter (or `CONAN_DOCKER_RUN_OPTIONS` envvar)
+When running `conan create` step in Docker, you might want to run the container with a different Docker network. For this you can use `docker_run_options` parameter (or `CONAN_DOCKER_RUN_OPTIONS` envvar)
 
     builder = ConanMultiPackager(
-      docker_run_options='--mount type=bind,source=$HOME/cached/conan-data,destination=/home/conan/.conan/data',
+      docker_run_options='--network bridge --privileged',
       ...
 
 When run, this will translate to something like this:
 
-    sudo -E docker run ... --mount type=bind,source=$HOME/cached/conan-data,destination=/home/conan/.conan/data  conanio/gcc6 /bin/sh -c "cd project &&  run_create_in_docker"
+    sudo -E docker run ... --network bridge --privileged conanio/gcc6 /bin/sh -c "cd project &&  run_create_in_docker"
 
 
 ### Installing custom Conan config

--- a/README.md
+++ b/README.md
@@ -431,7 +431,7 @@ But if you prefer to use environment variables:
     export CONAN_PIP_INSTALL="bincrafters-package-tools==0.17.0,conan-promote=0.1.2"
 
 ### Passing additional Docker parameters during build
-When running `conan create` step in Docker, you might want to run the container with additional parameters: for example, with `.conan/data` directory being mounted to parent system to avoid redownloading/rebuilding dependencies. For this you can use `docker_run_options` parameter
+When running `conan create` step in Docker, you might want to run the container with additional parameters: for example, with `.conan/data` directory being mounted to parent system to avoid redownloading/rebuilding dependencies. For this you can use `docker_run_options` parameter (or `CONAN_DOCKER_RUN_OPTIONS` envvar)
 
     builder = ConanMultiPackager(
       docker_run_options='--mount type=bind,source=$HOME/cached/conan-data,destination=/home/conan/.conan/data',
@@ -1153,6 +1153,7 @@ This is especially useful for CI integration.
 - **CONAN_TOTAL_PAGES**: Total number of pages
 - **CONAN_DOCKER_IMAGE**: If defined and docker is being used, it will use this dockerimage instead of the default images, e.g. "conanio/gcc63"
 - **CONAN_DOCKER_HOME**: Location where package source files will be copied to inside the Docker container
+- **CONAN_DOCKER_RUN_OPTIONS**: Pass additional parameters for docker when running the create step
 - **CONAN_DOCKER_IMAGE_SKIP_UPDATE**: If defined, it will skip the initialization update of "conan package tools" and "conan" in the docker image. By default is False.
 - **CONAN_DOCKER_IMAGE_SKIP_PULL**: If defined, it will skip the "docker pull" command, enabling a local image to be used, and without being overwritten.
 - **CONAN_ALWAYS_UPDATE_CONAN_DOCKER**: If defined, "conan package tools" and "conan" will be installed and upgraded in the docker image in every build execution

--- a/cpt/packager.py
+++ b/cpt/packager.py
@@ -249,7 +249,7 @@ class ConanMultiPackager(object):
         self.runner = runner or os.system
         self.output_runner = ConanOutputRunner()
 
-        self.docker_run_options = docker_run_options or os.getenv("CONAN_DOCKER_RUN_OPTIONS")
+        self.docker_run_options = docker_run_options or os.getenv("CONAN_DOCKER_RUN_OPTIONS", "")
 
         self.docker_entry_script = docker_entry_script or os.getenv("CONAN_DOCKER_ENTRY_SCRIPT")
 

--- a/cpt/packager.py
+++ b/cpt/packager.py
@@ -254,7 +254,9 @@ class ConanMultiPackager(object):
         self.runner = runner or os.system
         self.output_runner = ConanOutputRunner()
 
-        self.docker_run_options = docker_run_options or os.getenv("CONAN_DOCKER_RUN_OPTIONS", "")
+        self.docker_run_options = docker_run_options or split_colon_env("CONAN_DOCKER_RUN_OPTIONS")
+        if isinstance(self.docker_run_options, list):
+            self.docker_run_options = " ".join(self.docker_run_options)
 
         self.docker_entry_script = docker_entry_script or os.getenv("CONAN_DOCKER_ENTRY_SCRIPT")
 

--- a/cpt/packager.py
+++ b/cpt/packager.py
@@ -88,7 +88,7 @@ class ConanMultiPackager(object):
                  skip_check_credentials=False,
                  allow_gcc_minors=False,
                  exclude_vcvars_precommand=False,
-                 docker_build_options=None,
+                 docker_run_options=None,
                  docker_image_skip_update=False,
                  docker_image_skip_pull=False,
                  docker_entry_script=None,
@@ -249,7 +249,7 @@ class ConanMultiPackager(object):
         self.runner = runner or os.system
         self.output_runner = ConanOutputRunner()
 
-        self.docker_build_options = docker_build_options or os.getenv("CONAN_DOCKER_BUILD_OPTIONS")
+        self.docker_run_options = docker_run_options or os.getenv("CONAN_DOCKER_RUN_OPTIONS")
 
         self.docker_entry_script = docker_entry_script or os.getenv("CONAN_DOCKER_ENTRY_SCRIPT")
 
@@ -548,7 +548,7 @@ class ConanMultiPackager(object):
                                        docker_shell=self.docker_shell,
                                        docker_conan_home=self.docker_conan_home,
                                        docker_platform_param=self.docker_platform_param,
-                                       docker_build_options=self.docker_build_options,
+                                       docker_run_options=self.docker_run_options,
                                        lcow_user_workaround=self.lcow_user_workaround,
                                        test_folder=self.test_folder,
                                        pip_install=self.pip_install,

--- a/cpt/packager.py
+++ b/cpt/packager.py
@@ -267,7 +267,7 @@ class ConanMultiPackager(object):
 
         self.conan_pip_package = os.getenv("CONAN_PIP_PACKAGE", "conan==%s" % client_version)
         if self.conan_pip_package in ("0", "False"):
-            self.conan_pip_package = False
+            self.conan_pip_package = ""
         self.vs10_x86_64_enabled = vs10_x86_64_enabled
 
         self.builds_in_current_page = []
@@ -552,7 +552,8 @@ class ConanMultiPackager(object):
                                        lcow_user_workaround=self.lcow_user_workaround,
                                        test_folder=self.test_folder,
                                        pip_install=self.pip_install,
-                                       config_url=self.config_url)
+                                       config_url=self.config_url,
+                                       printer=self.printer)
 
                 r.run(pull_image=not pulled_docker_images[docker_image],
                       docker_entry_script=self.docker_entry_script)

--- a/cpt/packager.py
+++ b/cpt/packager.py
@@ -88,6 +88,7 @@ class ConanMultiPackager(object):
                  skip_check_credentials=False,
                  allow_gcc_minors=False,
                  exclude_vcvars_precommand=False,
+                 docker_build_options=None,
                  docker_image_skip_update=False,
                  docker_image_skip_pull=False,
                  docker_entry_script=None,
@@ -247,6 +248,8 @@ class ConanMultiPackager(object):
 
         self.runner = runner or os.system
         self.output_runner = ConanOutputRunner()
+
+        self.docker_build_options = docker_build_options or os.getenv("CONAN_DOCKER_BUILD_OPTIONS")
 
         self.docker_entry_script = docker_entry_script or os.getenv("CONAN_DOCKER_ENTRY_SCRIPT")
 
@@ -545,6 +548,7 @@ class ConanMultiPackager(object):
                                        docker_shell=self.docker_shell,
                                        docker_conan_home=self.docker_conan_home,
                                        docker_platform_param=self.docker_platform_param,
+                                       docker_build_options=self.docker_build_options,
                                        lcow_user_workaround=self.lcow_user_workaround,
                                        test_folder=self.test_folder,
                                        pip_install=self.pip_install,

--- a/cpt/runner.py
+++ b/cpt/runner.py
@@ -124,7 +124,7 @@ class DockerCreateRunner(object):
                  upload=False, upload_retry=None,
                  runner=None,
                  docker_shell="", docker_conan_home="",
-                 docker_platform_param="", docker_build_options="",
+                 docker_platform_param="", docker_run_options="",
                  lcow_user_workaround="",
                  test_folder=None,
                  pip_install=None,
@@ -148,7 +148,7 @@ class DockerCreateRunner(object):
         self._docker_shell = docker_shell
         self._docker_conan_home = docker_conan_home
         self._docker_platform_param = docker_platform_param
-        self._docker_build_options = docker_build_options or ""
+        self._docker_run_options = docker_run_options or ""
         self._lcow_user_workaround = lcow_user_workaround
         self._runner = PrintRunner(runner, self.printer)
         self._test_folder = test_folder
@@ -222,7 +222,7 @@ class DockerCreateRunner(object):
                                                   os.getcwd(),
                                                   self._docker_conan_home,
                                                   env_vars_text,
-                                                  self._docker_build_options,
+                                                  self._docker_run_options,
                                                   self._docker_platform_param,
                                                   self._docker_image,
                                                   self._docker_shell,

--- a/cpt/runner.py
+++ b/cpt/runner.py
@@ -128,9 +128,10 @@ class DockerCreateRunner(object):
                  lcow_user_workaround="",
                  test_folder=None,
                  pip_install=None,
-                 config_url=None):
+                 config_url=None,
+                 printer=None):
 
-        self.printer = Printer()
+        self.printer = printer or Printer()
         self._upload = upload
         self._upload_retry = upload_retry
         self._reference = reference

--- a/cpt/runner.py
+++ b/cpt/runner.py
@@ -200,8 +200,9 @@ class DockerCreateRunner(object):
                 with self.printer.foldable_output("update conan"):
                     try:
                         command = '%s docker run %s --name conan_runner ' \
-                                  ' %s %s "%s"' % (self._sudo_docker_command,
+                                  ' %s %s %s "%s"' % (self._sudo_docker_command,
                                                    env_vars_text,
+                                                   self._docker_run_options,
                                                    self._docker_image,
                                                    self._docker_shell,
                                                    self._pip_update_conan_command())

--- a/cpt/runner.py
+++ b/cpt/runner.py
@@ -124,7 +124,8 @@ class DockerCreateRunner(object):
                  upload=False, upload_retry=None,
                  runner=None,
                  docker_shell="", docker_conan_home="",
-                 docker_platform_param="", lcow_user_workaround="",
+                 docker_platform_param="", docker_build_options="",
+                 lcow_user_workaround="",
                  test_folder=None,
                  pip_install=None,
                  config_url=None):
@@ -147,6 +148,7 @@ class DockerCreateRunner(object):
         self._docker_shell = docker_shell
         self._docker_conan_home = docker_conan_home
         self._docker_platform_param = docker_platform_param
+        self._docker_build_options = docker_build_options or ""
         self._lcow_user_workaround = lcow_user_workaround
         self._runner = PrintRunner(runner, self.printer)
         self._test_folder = test_folder
@@ -214,12 +216,13 @@ class DockerCreateRunner(object):
         else:
             update_command = ""
 
-        command = ('%s docker run --rm -v "%s:%s/project" %s %s %s %s '
+        command = ('%s docker run --rm -v "%s:%s/project" %s %s %s %s %s '
                    '"%s cd project && '
                    '%s run_create_in_docker "' % (self._sudo_docker_command,
                                                   os.getcwd(),
                                                   self._docker_conan_home,
                                                   env_vars_text,
+                                                  self._docker_build_options,
                                                   self._docker_platform_param,
                                                   self._docker_image,
                                                   self._docker_shell,

--- a/cpt/test/integration/docker_test.py
+++ b/cpt/test/integration/docker_test.py
@@ -126,7 +126,7 @@ class Pkg(ConanFile):
                                        "CONAN_DOCKER_IMAGE": "conanio/gcc8",
                                        "CONAN_DOCKER_USE_SUDO": "0",
                                        "CONAN_REFERENCE": "foo/0.0.1@bar/testing",
-                                       "CONAN_DOCKER_RUN_OPTIONS": "--network=host"
+                                       "CONAN_DOCKER_RUN_OPTIONS": "--network=host, --add-host=google.com:8.8.8.8"
                                        }):
             self.packager = ConanMultiPackager(gcc_versions=["8"],
                                                archs=["x86_64"],
@@ -134,7 +134,7 @@ class Pkg(ConanFile):
                                                out=self.output.write)
             self.packager.add({})
             self.packager.run()
-            self.assertIn("--network=host  conanio/gcc8", self.output)
+            self.assertIn("--network=host --add-host=google.com:8.8.8.8  conanio/gcc8", self.output)
 
         # Validate by parameter
         with tools.environment_append({"CONAN_USERNAME": "bar",

--- a/cpt/test/integration/docker_test.py
+++ b/cpt/test/integration/docker_test.py
@@ -4,7 +4,7 @@ import time
 import unittest
 
 from conans import __version__ as client_version
-from conans.client import tools
+from conans import tools
 from conans.model.ref import ConanFileReference
 from conans.model.version import Version
 
@@ -15,13 +15,13 @@ from cpt.test.integration.base import BaseTest, PYPI_TESTING_REPO, CONAN_UPLOAD_
 from cpt.test.unit.utils import MockCIManager
 
 
+def is_linux_and_have_docker():
+    return tools.os_info.is_linux and tools.which("docker")
+
+
 class DockerTest(BaseTest):
 
-    @property
-    def is_linux_and_have_docker(self):
-        return sys.platform.startswith("linux") and tools.which("docker")
-
-    @unittest.skipUnless(is_linux_and_have_docker, "Requires Linux and Docker")
+    @unittest.skipUnless(is_linux_and_have_docker(), "Requires Linux and Docker")
     def test_docker(self):
         if not os.getenv("PYPI_PASSWORD", None):
             return
@@ -109,10 +109,8 @@ class Pkg(ConanFile):
             self.api.remove(search_pattern, remote_name="upload_repo", force=True)
 
 
-    @unittest.skipUnless(is_linux_and_have_docker, "Requires Linux and Docker")
+    @unittest.skipUnless(is_linux_and_have_docker(), "Requires Linux and Docker")
     def test_docker_run_options(self):
-        """ Run docker run --rm ... and look for extra option
-        """
         conanfile = """from conans import ConanFile
 import os
 
@@ -126,7 +124,7 @@ class Pkg(ConanFile):
         # Validate by Environemnt Variable
         with tools.environment_append({"CONAN_USERNAME": "bar",
                                        "CONAN_DOCKER_IMAGE": "conanio/gcc8",
-                                       "CONAN_DOCKER_USE_SUDO": "1",
+                                       "CONAN_DOCKER_USE_SUDO": "0",
                                        "CONAN_REFERENCE": "foo/0.0.1@bar/testing",
                                        "CONAN_DOCKER_RUN_OPTIONS": "--network=host"
                                        }):
@@ -141,7 +139,7 @@ class Pkg(ConanFile):
         # Validate by parameter
         with tools.environment_append({"CONAN_USERNAME": "bar",
                                        "CONAN_DOCKER_IMAGE": "conanio/gcc8",
-                                       "CONAN_DOCKER_USE_SUDO": "1",
+                                       "CONAN_DOCKER_USE_SUDO": "0",
                                        "CONAN_REFERENCE": "foo/0.0.1@bar/testing"
                                        }):
 


### PR DESCRIPTION
Changelog: Feature: Forward arguments to Docker run command (#310) (#277)

This is supposed to help with caching downloaded and/or built dependencies between frequent Travis builds.

My original thought was to introduce a parameter like `mount_docker_directory=str`, but I decided to side with generic Docker parameters since it seems more robust. Not sure about user-specified parameters for other docker steps though.

closes #310
closes #277 