### PR TITLE
fix azure pipelines branch detection

### DIFF
--- a/cpt/ci_manager.py
+++ b/cpt/ci_manager.py
@@ -270,7 +270,10 @@ class AzurePipelinesManager(GenericManager):
         return os.getenv("BUILD_SOURCEVERSION", None)
 
     def get_branch(self):
-        return os.getenv("BUILD_SOURCEBRANCHNAME", None)
+        branch = os.getenv("BUILD_SOURCEBRANCH", None)
+        if branch.startswith("refs/heads/"):
+            branch = branch[11:]
+        return branch
 
     def is_pull_request(self):
         return os.getenv("BUILD_REASON", "false") == "PullRequest"

--- a/cpt/test/unit/ci_manager_test.py
+++ b/cpt/test/unit/ci_manager_test.py
@@ -121,11 +121,35 @@ class CIManagerTest(unittest.TestCase):
         with tools.environment_append({"SYSTEM_TEAMFOUNDATIONCOLLECTIONURI": "https://dev.azure.com/",
                                        "BUILD_SOURCEVERSIONMESSAGE": "msg",
                                        "BUILD_SOURCEVERSION": "506c89117650bb12252db26d35b8c2385411f175",
-                                       "BUILD_SOURCEBRANCHNAME": "mybranch",
+                                       "BUILD_SOURCEBRANCH": "mybranch",
                                        "BUILD_REASON": "manual",
                                        }):
             manager = CIManager(self.printer)
             self.assertEquals(manager.get_branch(), "mybranch")
+            self.assertEquals(manager.get_commit_msg(), "msg")
+            self.assertEquals(manager.get_commit_id(), "506c89117650bb12252db26d35b8c2385411f175")
+            self.assertEquals(manager.is_pull_request(), False)
+
+        with tools.environment_append({"SYSTEM_TEAMFOUNDATIONCOLLECTIONURI": "https://dev.azure.com/",
+                                       "BUILD_SOURCEVERSIONMESSAGE": "msg",
+                                       "BUILD_SOURCEVERSION": "506c89117650bb12252db26d35b8c2385411f175",
+                                       "BUILD_SOURCEBRANCH": "refs/heads/testing/version",
+                                       "BUILD_REASON": "PullRequest",
+                                       }):
+            manager = CIManager(self.printer)
+            self.assertEquals(manager.get_branch(), "testing/version")
+            self.assertEquals(manager.get_commit_msg(), "msg")
+            self.assertEquals(manager.get_commit_id(), "506c89117650bb12252db26d35b8c2385411f175")
+            self.assertEquals(manager.is_pull_request(), True)
+
+        with tools.environment_append({"SYSTEM_TEAMFOUNDATIONCOLLECTIONURI": "https://dev.azure.com/",
+                                       "BUILD_SOURCEVERSIONMESSAGE": "msg",
+                                       "BUILD_SOURCEVERSION": "506c89117650bb12252db26d35b8c2385411f175",
+                                       "BUILD_SOURCEBRANCH": "refs/heads/stable/version",
+                                       "BUILD_REASON": "IndividualCI",
+                                       }):
+            manager = CIManager(self.printer)
+            self.assertEquals(manager.get_branch(), "stable/version")
             self.assertEquals(manager.get_commit_msg(), "msg")
             self.assertEquals(manager.get_commit_id(), "506c89117650bb12252db26d35b8c2385411f175")
             self.assertEquals(manager.is_pull_request(), False)


### PR DESCRIPTION
Changelog: Bugfix: Fix Azure DevOps branch name (#346)

use variable BUILD_SOURCEBRANCH
BUILD_SOURCEBRANCHNAME only has the part after last /