### PR TITLE
Accept custom pip command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1154,6 +1154,7 @@ This is especially useful for CI integration.
 - **CONAN_BASH_PATH**: Path to a bash executable. Used only in windows to help the tools.run_in_windows_bash() function to locate our Cygwin/MSYS2 bash.
   Set it with the bash executable path if it’s not in the PATH or you want to use a different one.
 - **CONAN_PIP_USE_SUDO** Use "sudo" when invoking pip, by default it will use sudo when not using Windows and not running docker image "conanio/". "False" to deactivate.
+- **CONAN_PIP_COMMAND** Run custom `pip` command when updating Conan. e.g. "/usr/bin/pip2"
 - **CONAN_DOCKER_USE_SUDO** Use "sudo" when invoking docker, by default it will use sudo when not using Windows. "False" to deactivate.
 - **CONAN_ALLOW_GCC_MINORS** Declare this variable if you want to allow gcc >=5 versions with the minor (5.1, 6.3 etc).
 - **CONAN_EXCLUDE_VCVARS_PRECOMMAND** For Visual Studio builds, it exclude the vcvars call to set the environment.

--- a/cpt/packager.py
+++ b/cpt/packager.py
@@ -218,6 +218,7 @@ class ConanMultiPackager(object):
             self.sudo_pip_command = "sudo -E" if get_bool_from_env("CONAN_PIP_USE_SUDO") else ""
         elif platform.system() != "Windows" and self._docker_image and 'conanio/' not in str(self._docker_image):
             self.sudo_pip_command = "sudo -E"
+        self.pip_command = os.getenv("CONAN_PIP_COMMAND", "pip")
 
         self.docker_shell = ""
 
@@ -439,12 +440,14 @@ class ConanMultiPackager(object):
                 self.auth_manager.login(self.remotes_manager.upload_remote_name)
             if self.conan_pip_package and not self.use_docker:
                 with self.printer.foldable_output("pip_update"):
-                    self.runner('%s pip install %s' % (self.sudo_pip_command,
-                                                       self.conan_pip_package))
+                    self.runner('%s %s install %s' % (self.sudo_pip_command,
+                                                      self.pip_command,
+                                                      self.conan_pip_package))
                     if self.pip_install:
                         packages = " ".join(self.pip_install)
                         self.printer.print_message("Install extra python packages: {}".format(packages))
-                        self.runner('%s pip install %s' % (self.sudo_pip_command, packages))
+                        self.runner('%s %s install %s' % (self.sudo_pip_command,
+                                                          self.pip_command, packages))
 
             self.run_builds(base_profile_name=base_profile_name)
 

--- a/cpt/packager.py
+++ b/cpt/packager.py
@@ -219,6 +219,8 @@ class ConanMultiPackager(object):
         elif platform.system() != "Windows" and self._docker_image and 'conanio/' not in str(self._docker_image):
             self.sudo_pip_command = "sudo -E"
         self.pip_command = os.getenv("CONAN_PIP_COMMAND", "pip")
+        if not tools.which(self.pip_command) or not "pip" in self.pip_command:
+            raise Exception("CONAN_PIP_COMMAND: '{}' is not a valid pip command.".format(self.pip_command))
 
         self.docker_shell = ""
 

--- a/cpt/packager.py
+++ b/cpt/packager.py
@@ -219,7 +219,8 @@ class ConanMultiPackager(object):
         elif platform.system() != "Windows" and self._docker_image and 'conanio/' not in str(self._docker_image):
             self.sudo_pip_command = "sudo -E"
         self.pip_command = os.getenv("CONAN_PIP_COMMAND", "pip")
-        if not tools.which(self.pip_command) or not "pip" in self.pip_command:
+        pip_found = True if tools.os_info.is_windows else tools.which(self.pip_command)
+        if not pip_found or not "pip" in self.pip_command:
             raise Exception("CONAN_PIP_COMMAND: '{}' is not a valid pip command.".format(self.pip_command))
 
         self.docker_shell = ""

--- a/cpt/packager.py
+++ b/cpt/packager.py
@@ -443,13 +443,13 @@ class ConanMultiPackager(object):
                 self.auth_manager.login(self.remotes_manager.upload_remote_name)
             if self.conan_pip_package and not self.use_docker:
                 with self.printer.foldable_output("pip_update"):
-                    self.runner('%s %s install %s' % (self.sudo_pip_command,
+                    self.runner('%s %s install -q %s' % (self.sudo_pip_command,
                                                       self.pip_command,
                                                       self.conan_pip_package))
                     if self.pip_install:
                         packages = " ".join(self.pip_install)
                         self.printer.print_message("Install extra python packages: {}".format(packages))
-                        self.runner('%s %s install %s' % (self.sudo_pip_command,
+                        self.runner('%s %s install -q %s' % (self.sudo_pip_command,
                                                           self.pip_command, packages))
 
             self.run_builds(base_profile_name=base_profile_name)

--- a/cpt/test/unit/packager_test.py
+++ b/cpt/test/unit/packager_test.py
@@ -8,6 +8,7 @@ from collections import defaultdict
 from cpt.builds_generator import BuildConf
 from cpt.packager import ConanMultiPackager
 from conans import tools
+from conans.test.utils.tools import TestBufferConanOutput
 from conans.model.ref import ConanFileReference
 from cpt.test.unit.utils import MockConanAPI, MockRunner, MockCIManager
 
@@ -817,3 +818,44 @@ class AppTest(unittest.TestCase):
         self._add_build(1, "gcc", "4.3")
         self.packager.run_builds(1, 2)
         self.assertIn("sudo -E pip", self.runner.calls[1])
+
+    def test_regular_pip_command(self):
+        """ CPT Should call `pip` when CONAN_PIP_PACKAGE or CONAN_PIP_INSTALL are declared.
+        """
+        with tools.environment_append({"CONAN_USERNAME": "foobar",
+                                       "CONAN_PIP_PACKAGE": "conan==1.0.0-dev",
+                                       "CONAN_PIP_INSTALL": "foobar==0.1.0"}):
+            output = TestBufferConanOutput()
+            self.packager = ConanMultiPackager(username="lasote",
+                                               channel="mychannel",
+                                               reference="lib/1.0",
+                                               ci_manager=self.ci_manager,
+                                               out=output.write,
+                                               conan_api=self.conan_api,
+                                               runner=self.runner)
+            self.packager.add_common_builds()
+            self.packager.run()
+            self.assertIn("[pip_update]", output)
+            self.assertIn(" pip install conan==1.0.0-dev", self.runner.calls)
+            self.assertIn(" pip install foobar==0.1.0", self.runner.calls)
+
+    def test_custom_pip_command(self):
+        """ CPT should run custom `pip` path when CONAN_PIP_COMMAND is declared.
+        """
+        with tools.environment_append({"CONAN_USERNAME": "foobar",
+                                       "CONAN_PIP_PACKAGE": "conan==0.1.0",
+                                       "CONAN_PIP_INSTALL": "foobar==0.1.0",
+                                       "CONAN_PIP_COMMAND": "/usr/bin/pip3"}):
+            output = TestBufferConanOutput()
+            self.packager = ConanMultiPackager(username="lasote",
+                                               channel="mychannel",
+                                               reference="lib/1.0",
+                                               ci_manager=self.ci_manager,
+                                               out=output.write,
+                                               conan_api=self.conan_api,
+                                               runner=self.runner)
+            self.packager.add_common_builds()
+            self.packager.run()
+            self.assertIn("[pip_update]", output)
+            self.assertIn(" /usr/bin/pip3 install conan==0.1.0", self.runner.calls)
+            self.assertIn(" /usr/bin/pip3 install foobar==0.1.0", self.runner.calls)

--- a/cpt/test/unit/packager_test.py
+++ b/cpt/test/unit/packager_test.py
@@ -842,10 +842,11 @@ class AppTest(unittest.TestCase):
     def test_custom_pip_command(self):
         """ CPT should run custom `pip` path when CONAN_PIP_COMMAND is declared.
         """
+        pip = "pip3" if tools.which("pip3") else "pip2"
         with tools.environment_append({"CONAN_USERNAME": "foobar",
                                        "CONAN_PIP_PACKAGE": "conan==0.1.0",
                                        "CONAN_PIP_INSTALL": "foobar==0.1.0",
-                                       "CONAN_PIP_COMMAND": "pip3"}):
+                                       "CONAN_PIP_COMMAND": pip}):
             output = TestBufferConanOutput()
             self.packager = ConanMultiPackager(username="lasote",
                                                channel="mychannel",
@@ -857,8 +858,8 @@ class AppTest(unittest.TestCase):
             self.packager.add_common_builds()
             self.packager.run()
             self.assertIn("[pip_update]", output)
-            self.assertIn(" pip3 install conan==0.1.0", self.runner.calls)
-            self.assertIn(" pip3 install foobar==0.1.0", self.runner.calls)
+            self.assertIn(" {} install conan==0.1.0".format(pip), self.runner.calls)
+            self.assertIn(" {} install foobar==0.1.0".format(pip), self.runner.calls)
 
     def test_invalid_pip_command(self):
         """ CPT should not accept invalid `pip` command when CONAN_PIP_COMMAND is declared.

--- a/cpt/test/unit/packager_test.py
+++ b/cpt/test/unit/packager_test.py
@@ -836,8 +836,8 @@ class AppTest(unittest.TestCase):
             self.packager.add_common_builds()
             self.packager.run()
             self.assertIn("[pip_update]", output)
-            self.assertIn(" pip install conan==1.0.0-dev", self.runner.calls)
-            self.assertIn(" pip install foobar==0.1.0", self.runner.calls)
+            self.assertIn(" pip install -q conan==1.0.0-dev", self.runner.calls)
+            self.assertIn(" pip install -q foobar==0.1.0", self.runner.calls)
 
     def test_custom_pip_command(self):
         """ CPT should run custom `pip` path when CONAN_PIP_COMMAND is declared.
@@ -858,8 +858,8 @@ class AppTest(unittest.TestCase):
             self.packager.add_common_builds()
             self.packager.run()
             self.assertIn("[pip_update]", output)
-            self.assertIn(" {} install conan==0.1.0".format(pip), self.runner.calls)
-            self.assertIn(" {} install foobar==0.1.0".format(pip), self.runner.calls)
+            self.assertIn(" {} install -q conan==0.1.0".format(pip), self.runner.calls)
+            self.assertIn(" {} install -q foobar==0.1.0".format(pip), self.runner.calls)
 
     def test_invalid_pip_command(self):
         """ CPT should not accept invalid `pip` command when CONAN_PIP_COMMAND is declared.

--- a/cpt/test/unit/packager_test.py
+++ b/cpt/test/unit/packager_test.py
@@ -832,7 +832,8 @@ class AppTest(unittest.TestCase):
                                                ci_manager=self.ci_manager,
                                                out=output.write,
                                                conan_api=self.conan_api,
-                                               runner=self.runner)
+                                               runner=self.runner,
+                                               exclude_vcvars_precommand=True)
             self.packager.add_common_builds()
             self.packager.run()
             self.assertIn("[pip_update]", output)
@@ -854,7 +855,8 @@ class AppTest(unittest.TestCase):
                                                ci_manager=self.ci_manager,
                                                out=output.write,
                                                conan_api=self.conan_api,
-                                               runner=self.runner)
+                                               runner=self.runner,
+                                               exclude_vcvars_precommand=True)
             self.packager.add_common_builds()
             self.packager.run()
             self.assertIn("[pip_update]", output)
@@ -875,7 +877,8 @@ class AppTest(unittest.TestCase):
                                                 ci_manager=self.ci_manager,
                                                 out=output.write,
                                                 conan_api=self.conan_api,
-                                                runner=self.runner)
+                                                runner=self.runner,
+                                                exclude_vcvars_precommand=True)
                 self.packager.add_common_builds()
                 self.packager.run()
 


### PR DESCRIPTION
Hi!

Add the env var **CONAN_PIP_COMMAND** to customize which command will be executed when running `pip install`.

- The command must contain `pip` in the name;
- The command can be an absolute file path e.g. /usr/bin/pip3
- The command must be valid in the PATH.

Changelog: Feature: Customize pip command name (#147)

fixes #147 
/cc @koliyo