### PR TITLE
Feature/upload only recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -798,8 +798,6 @@ You can upload the generated packages automatically to a conan-server using the 
         CONAN_STABLE_BRANCH_PATTERN: "release/*"
 
 
-<<<<<<< HEAD
-=======
 ## Upload dependencies ([#237](https://github.com/conan-io/conan-package-tools/issues/237))
 
 Sometimes your dependencies are not available in remotes and you need to pass ``--build=missing`` to build them.
@@ -821,7 +819,6 @@ Or,
 
     ConanMultiPackager(upload_dependencies=["foo/0.1@user/channel", "bar/1.2@bar/channel"])
 
->>>>>>> upstream/develop
 ## Pagination
 
 Sometimes, if your library is big or complex enough in terms of compilation time, the CI server could reach the maximum time of execution,

--- a/README.md
+++ b/README.md
@@ -798,7 +798,6 @@ You can upload the generated packages automatically to a conan-server using the 
         CONAN_STABLE_BRANCH_PATTERN: "release/*"
 
 
-
 ## Pagination
 
 Sometimes, if your library is big or complex enough in terms of compilation time, the CI server could reach the maximum time of execution,
@@ -1022,6 +1021,7 @@ Using **CONAN_CLANG_VERSIONS** env variable in Travis ci or Appveyor:
 - **upload_retry**: Num retries in upload in case of failure.
 - **upload_only_when_stable**: Will try to upload only if the channel is the stable channel. Default [False]
 - **upload_only_when_tag**: Will try to upload only if the branch is a tag. Default [False]
+- **upload_only_recipe**: If defined, will try to upload **only** the recipes. The built packages will **not** be uploaded. Default [False]
 - **build_types**: List containing specific build types. Default ["Release", "Debug"]
 - **skip_check_credentials**: Conan will skip checking the user credentials before building the packages. And if no user/remote is specified, will try to upload with the
   already stored credentiales in the local cache. Default [False]
@@ -1122,6 +1122,7 @@ This is especially useful for CI integration.
 - **CONAN_UPLOAD_RETRY**: If defined, in case of fail retries to upload again the specified times
 - **CONAN_UPLOAD_ONLY_WHEN_STABLE**: If defined, will try to upload the packages only when the current channel is the stable one.
 - **CONAN_UPLOAD_ONLY_WHEN_TAG**: If defined, will try to upload the packages only when the current branch is a tag.
+- **CONAN_UPLOAD_ONLY_RECIPE**: If defined, will try to upload **only** the recipes. The built packages will **not** be uploaded.
 
 - **CONAN_SKIP_CHECK_CREDENTIALS**: Conan will skip checking the user credentials before building the packages. And if no user/remote is specified, will try to upload with the
   already stored credentiales in the local cache. Default [False]

--- a/cpt/packager.py
+++ b/cpt/packager.py
@@ -144,7 +144,7 @@ class ConanMultiPackager(object):
         else:
             self.upload_only_when_tag = get_bool_from_env("CONAN_UPLOAD_ONLY_WHEN_TAG")
 
-        self.upload_only_recipe = upload_only_when_tag or get_bool_from_env("CONAN_UPLOAD_ONLY_RECIPE")
+        self.upload_only_recipe = upload_only_recipe or get_bool_from_env("CONAN_UPLOAD_ONLY_RECIPE")
 
         self.uploader = Uploader(self.conan_api, self.remotes_manager, self.auth_manager,
                                  self.printer, self.upload_retry)

--- a/cpt/packager.py
+++ b/cpt/packager.py
@@ -84,6 +84,7 @@ class ConanMultiPackager(object):
                  login_username=None,
                  upload_only_when_stable=None,
                  upload_only_when_tag=None,
+                 upload_only_recipe=None,
                  build_types=None,
                  skip_check_credentials=False,
                  allow_gcc_minors=False,
@@ -142,6 +143,8 @@ class ConanMultiPackager(object):
             self.upload_only_when_tag = upload_only_when_tag
         else:
             self.upload_only_when_tag = get_bool_from_env("CONAN_UPLOAD_ONLY_WHEN_TAG")
+
+        self.upload_only_recipe = upload_only_when_tag or get_bool_from_env("CONAN_UPLOAD_ONLY_RECIPE")
 
         self.uploader = Uploader(self.conan_api, self.remotes_manager, self.auth_manager,
                                  self.printer, self.upload_retry)
@@ -524,6 +527,7 @@ class ConanMultiPackager(object):
                                  cwd=self.cwd,
                                  printer=self.printer,
                                  upload=self._upload_enabled(),
+                                 upload_retry=self.upload_retry,
                                  test_folder=self.test_folder,
                                  config_url=self.config_url)
                 r.run()
@@ -541,6 +545,7 @@ class ConanMultiPackager(object):
                                        always_update_conan_in_docker=self._update_conan_in_docker,
                                        upload=self._upload_enabled(),
                                        upload_retry=self.upload_retry,
+                                       upload_only_recipe=self.upload_only_recipe
                                        runner=self.runner,
                                        docker_shell=self.docker_shell,
                                        docker_conan_home=self.docker_conan_home,

--- a/cpt/packager.py
+++ b/cpt/packager.py
@@ -527,7 +527,7 @@ class ConanMultiPackager(object):
                                  cwd=self.cwd,
                                  printer=self.printer,
                                  upload=self._upload_enabled(),
-                                 upload_retry=self.upload_retry,
+                                 upload_only_recipe=self.upload_only_recipe,
                                  test_folder=self.test_folder,
                                  config_url=self.config_url)
                 r.run()
@@ -545,7 +545,7 @@ class ConanMultiPackager(object):
                                        always_update_conan_in_docker=self._update_conan_in_docker,
                                        upload=self._upload_enabled(),
                                        upload_retry=self.upload_retry,
-                                       upload_only_recipe=self.upload_only_recipe
+                                       upload_only_recipe=self.upload_only_recipe,
                                        runner=self.runner,
                                        docker_shell=self.docker_shell,
                                        docker_conan_home=self.docker_conan_home,

--- a/cpt/run_in_docker.py
+++ b/cpt/run_in_docker.py
@@ -24,6 +24,7 @@ def run():
     auth_manager = AuthManager(conan_api, printer, default_username=default_username)
 
     upload_retry = os.getenv("CPT_UPLOAD_RETRY")
+    upload_only_recipe = os.getenv("CPT_UPLOAD_ONLY_RECIPE")
     uploader = Uploader(conan_api, remotes_manager, auth_manager, printer, upload_retry)
     build_policy = unscape_env(os.getenv("CPT_BUILD_POLICY"))
     test_folder = unscape_env(os.getenv("CPT_TEST_FOLDER"))
@@ -41,6 +42,7 @@ def run():
     upload = os.getenv("CPT_UPLOAD_ENABLED")
     runner = CreateRunner(abs_profile_path, reference, conan_api, uploader,
                           build_policy=build_policy, printer=printer, upload=upload,
+                          upload_only_recipe=upload_only_recipe,
                           test_folder=test_folder, config_url=config_url)
     runner.run()
 

--- a/cpt/test/test_client/upload_checks_test.py
+++ b/cpt/test/test_client/upload_checks_test.py
@@ -101,3 +101,40 @@ class Pkg(ConanFile):
             self.assertIn("Redefined channel by branch tag", tc.out)
             self.assertIn("Uploading packages for 'lib/1.0@user/stable'", tc.out)
             self.assertIn("Uploading package 1/1: 5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9 to 'default'", tc.out)
+
+    def test_upload_only_recipe(self):
+        """ When CONAN_UPLOAD_ONLY_RECIPE is TRUE, binary must not be uploaded.
+        """
+        ts = TestServer(users={"user": "password"})
+        tc = TestClient(servers={"default": ts}, users={"default": [("user", "password")]})
+        tc.save({"conanfile.py": self.conanfile})
+
+        # Upload only the recipe
+        with environment_append({"CONAN_UPLOAD": ts.fake_url, "CONAN_LOGIN_USERNAME": "user",
+                                "CONAN_PASSWORD": "password", "CONAN_USERNAME": "user",
+                                "CONAN_UPLOAD_ONLY_RECIPE": "TRUE"}):
+            mulitpackager = get_patched_multipackager(tc, exclude_vcvars_precommand=True)
+            mulitpackager.add({}, {"shared": True})
+            mulitpackager.add({}, {"shared": False})
+            mulitpackager.run()
+
+            self.assertIn(" Uploading packages for 'lib/1.0@user/testing'", tc.out)
+            self.assertIn("Uploading lib/1.0@user/testing to remote", tc.out)
+            self.assertIn("Uploaded conan recipe 'lib/1.0@user/testing'", tc.out)
+            self.assertNotIn("Uploading package 1/2", tc.out)
+            self.assertNotIn("Uploading package 2/2", tc.out)
+
+        # Re-use cache the upload the binary packages
+        with environment_append({"CONAN_UPLOAD": ts.fake_url, "CONAN_LOGIN_USERNAME": "user",
+                                "CONAN_PASSWORD": "password", "CONAN_USERNAME": "user",
+                                "CONAN_UPLOAD_ONLY_RECIPE": "FALSE"}):
+            mulitpackager = get_patched_multipackager(tc, exclude_vcvars_precommand=True)
+            mulitpackager.add({}, {"shared": True})
+            mulitpackager.add({}, {"shared": False})
+            mulitpackager.run()
+
+            self.assertIn(" Uploading packages for 'lib/1.0@user/testing'", tc.out)
+            self.assertIn("Uploading lib/1.0@user/testing to remote", tc.out)
+            self.assertIn("Recipe is up to date, upload skipped", tc.out)
+            self.assertIn("Uploading package 1/2", tc.out)
+            self.assertIn("Uploading package 2/2", tc.out)

--- a/cpt/test/test_client/upload_checks_test.py
+++ b/cpt/test/test_client/upload_checks_test.py
@@ -103,8 +103,6 @@ class Pkg(ConanFile):
             self.assertIn("Uploading package 1/1: 5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9 to 'default'", tc.out)
 
     def test_upload_only_recipe(self):
-        """ When CONAN_UPLOAD_ONLY_RECIPE is TRUE, binary must not be uploaded.
-        """
         ts = TestServer(users={"user": "password"})
         tc = TestClient(servers={"default": ts}, users={"default": [("user", "password")]})
         tc.save({"conanfile.py": self.conanfile})
@@ -118,9 +116,9 @@ class Pkg(ConanFile):
             mulitpackager.add({}, {"shared": False})
             mulitpackager.run()
 
-            self.assertIn(" Uploading packages for 'lib/1.0@user/testing'", tc.out)
-            self.assertIn("Uploading lib/1.0@user/testing to remote", tc.out)
-            self.assertIn("Uploaded conan recipe 'lib/1.0@user/testing'", tc.out)
+            self.assertIn(" Uploading packages for 'lib/1.0@user/mychannel'", tc.out)
+            self.assertIn("Uploading lib/1.0@user/mychannel to remote", tc.out)
+            self.assertIn("Uploaded conan recipe 'lib/1.0@user/mychannel'", tc.out)
             self.assertNotIn("Uploading package 1/2", tc.out)
             self.assertNotIn("Uploading package 2/2", tc.out)
 
@@ -133,8 +131,8 @@ class Pkg(ConanFile):
             mulitpackager.add({}, {"shared": False})
             mulitpackager.run()
 
-            self.assertIn(" Uploading packages for 'lib/1.0@user/testing'", tc.out)
-            self.assertIn("Uploading lib/1.0@user/testing to remote", tc.out)
+            self.assertIn(" Uploading packages for 'lib/1.0@user/mychannel'", tc.out)
+            self.assertIn("Uploading lib/1.0@user/mychannel to remote", tc.out)
             self.assertIn("Recipe is up to date, upload skipped", tc.out)
             self.assertIn("Uploading package 1/2", tc.out)
             self.assertIn("Uploading package 2/2", tc.out)

--- a/cpt/tools.py
+++ b/cpt/tools.py
@@ -4,7 +4,7 @@ import os
 def get_bool_from_env(var_name):
     import os
     val = os.getenv(var_name, None)
-    return val not in (None, "0", "None", "False")
+    return str(val).lower() not in ("0", "none", "false")
 
 
 def split_colon_env(varname):

--- a/cpt/uploader.py
+++ b/cpt/uploader.py
@@ -9,7 +9,13 @@ class Uploader(object):
         if not self._upload_retry:
             self._upload_retry = 0
 
+    def upload_recipe(self, reference, upload):
+        self._upload_artifacts(reference, upload)
+
     def upload_packages(self, reference, upload, package_id):
+        self._upload_artifacts(reference, upload, package_id)
+
+    def _upload_artifacts(self, reference, upload, package_id=None):
         remote_name = self.remote_manager.upload_remote_name
         if not remote_name:
             self.printer.print_message("Upload skipped, not upload remote available")
@@ -37,8 +43,9 @@ class Uploader(object):
                                       force=True,
                                       retry=int(self._upload_retry))
             elif Version(client_version) < Version("1.14.0"):
+                all_packages = package_id != None
                 self.conan_api.upload(str(reference),
-                                      all_packages=True,
+                                      all_packages=all_packages,
                                       remote_name=remote_name,
                                       retry=int(self._upload_retry))
             else:


### PR DESCRIPTION
Changelog: Feature: Upload only the Conan recipe (#153) (#25)

Add the option **CONAN_UPLOAD_ONLY_RECIPE** which allows to upload only the recipe when is True.

fixes #153 
fixes #25