### PR TITLE
#282 Add CONAN_REMOVE_OUTDATE_PACKAGES option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1032,6 +1032,7 @@ Using **CONAN_CLANG_VERSIONS** env variable in Travis ci or Appveyor:
     - "missing": Build only missing packages.
     - "outdated": Build only missing or if the available package is not built with the current recipe. Useful to upload new configurations, e.j packages for a new compiler without
       rebuild all packages.
+- **remove_outdated_packages**: Remove all outdated packages from remote after to upload a package. Default [False]
 - **test_folder**: Custom test folder consumed by Conan create, e.j .conan/test_package
 - **config_url**: Conan config URL be installed before to build e.j https://github.com/bincrafters/conan-config.git
 
@@ -1167,6 +1168,7 @@ This is especially useful for CI integration.
 - **CONAN_CONFIG_URL**: Conan config URL be installed before to build e.j https://github.com/bincrafters/conan-config.git
 - **CONAN_BASE_PROFILE**: Apply options, settings, etc. to this profile instead of `default`.
 - **CONAN_IGNORE_SKIP_CI**: Ignore `[skip ci]` in commit message.
+- **CONAN_REMOVE_OUTDATED_PACKAGES**: Remove all outdated packages from remote after to upload a package. Default [False]
 - **CPT_TEST_FOLDER**: Custom test_package path, e.j .conan/test_package
 
 

--- a/cpt/eraser.py
+++ b/cpt/eraser.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+
+class Eraser(object):
+    """ Helper to connect on remove and remove outdated packages
+    """
+
+    def __init__(self, conan_api, remote_manager, auth_manager, printer, remove):
+        """ Initialize Eraser instance
+        :param conan_api: Conan API instance
+        :param remote_manager: Remote manager instance
+        :param auth_manager: Authication manager to access the remote
+        :param printer: CPT output
+        :param remove: True if should remove outdated packages from remote. Otherwise, False.
+        """
+        self.conan_api = conan_api
+        self.remote_manager = remote_manager
+        self.auth_manager = auth_manager
+        self.printer = printer
+        self.remove = remove
+
+    def remove_outdated_packages(self, reference):
+        """ Remove outdated packages from remote
+        :param reference: Package reference e.g. foo/0.1.0@user/channel
+        """
+        if not self.remote_manager or not self.remote_manager.upload_remote_name:
+            self.printer.print_message("Remove outdated skipped, no remote available")
+            return
+        remote_name = self.remote_manager.upload_remote_name
+
+        if not self.auth_manager or not self.auth_manager.credentials_ready(remote_name):
+            self.printer.print_message("Remove outdated skipped, credentials for remote '%s' not available" % remote_name)
+            return
+
+        if self.remove:
+            self.printer.print_message("Removing outdated packages for '%s'" % str(reference))
+            self.auth_manager.login(remote_name)
+            self.conan_api.remove(pattern=str(reference),
+                                  force=True,
+                                  remote_name=remote_name,
+                                  outdated=True)

--- a/cpt/run_in_docker.py
+++ b/cpt/run_in_docker.py
@@ -10,6 +10,7 @@ from cpt.profiles import save_profile_to_tmp
 from cpt.remotes import RemotesManager
 from cpt.runner import CreateRunner, unscape_env
 from cpt.uploader import Uploader
+from cpt.eraser import Eraser
 
 
 def run():
@@ -29,6 +30,9 @@ def run():
     test_folder = unscape_env(os.getenv("CPT_TEST_FOLDER"))
     reference = ConanFileReference.loads(os.getenv("CONAN_REFERENCE"))
 
+    remove_outdated_packages = unscape_env(os.getenv("CPT_REMOVE_OUTDATED_PACKAGES"))
+    eraser = Eraser(conan_api, remotes_manager, auth_manager, printer, remove_outdated_packages)
+
     profile_text = unscape_env(os.getenv("CPT_PROFILE"))
     abs_profile_path = save_profile_to_tmp(profile_text)
     base_profile_text = unscape_env(os.getenv("CPT_BASE_PROFILE"))
@@ -39,7 +43,7 @@ def run():
                    base_profile_text)
 
     upload = os.getenv("CPT_UPLOAD_ENABLED")
-    runner = CreateRunner(abs_profile_path, reference, conan_api, uploader,
+    runner = CreateRunner(abs_profile_path, reference, conan_api, uploader, eraser=eraser,
                           build_policy=build_policy, printer=printer, upload=upload,
                           test_folder=test_folder, config_url=config_url)
     runner.run()

--- a/cpt/test/test_client/erase_checks_test.py
+++ b/cpt/test/test_client/erase_checks_test.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+import unittest
+
+from conans.client.tools import environment_append
+from conans.test.utils.tools import TestClient, TestServer
+
+from cpt.test.test_client.tools import get_patched_multipackager
+
+
+class EraseTest(unittest.TestCase):
+
+    old_conanfile = """from conans import ConanFile
+class Pkg(ConanFile):
+    name = "lib"
+    version = "1.0"
+    options = {"shared": [True, False]}
+    default_options = "shared=False"
+
+    def build(self):
+        self.output.warn("OLD")
+"""
+
+    new_conanfile = """from conans import ConanFile
+class Pkg(ConanFile):
+    name = "lib"
+    version = "1.0"
+    options = {"shared": [True, False], "foo": [True, False]}
+    default_options = "shared=False", "foo=True"
+
+    def build(self):
+        self.output.warn("NEW")
+"""
+
+    def test_remove_updated_packages_env_var(self):
+        ts = TestServer(users={"user": "password"})
+        tc = TestClient(servers={"default": ts}, users={"default": [("user", "password")]})
+        tc.save({"conanfile.py": self.old_conanfile})
+        with environment_append({"CONAN_UPLOAD": ts.fake_url, "CONAN_LOGIN_USERNAME": "user",
+                                 "CONAN_PASSWORD": "password", "CONAN_USERNAME": "user",
+                                 "CONAN_REMOVE_OUTDATED_PACKAGES": "1"}):
+            mulitpackager = get_patched_multipackager(tc, build_policy="missing",
+                                                      exclude_vcvars_precommand=True)
+            mulitpackager.add({}, {"shared": True})
+            mulitpackager.add({}, {"shared": False})
+            mulitpackager.run()
+            self.assertIn("Uploading package 1/2", tc.out)
+            self.assertIn("Uploading package 2/2", tc.out)
+            self.assertIn("OLD", tc.out)
+            self.assertIn("Removing outdated packages for 'lib/1.0@user/testing'", tc.out)
+
+    def test_remove_updated_packages_params(self):
+        ts = TestServer(users={"user": "password"})
+        tc = TestClient(servers={"default": ts}, users={"default": [("user", "password")]})
+        tc.save({"conanfile.py": self.old_conanfile})
+        with environment_append({"CONAN_UPLOAD": ts.fake_url, "CONAN_LOGIN_USERNAME": "user",
+                                 "CONAN_PASSWORD": "password", "CONAN_USERNAME": "user"}):
+            mulitpackager = get_patched_multipackager(tc, build_policy="missing",
+                                                      exclude_vcvars_precommand=True,
+                                                      remove_outdated_packages=True)
+            mulitpackager.add({}, {"shared": True})
+            mulitpackager.add({}, {"shared": False})
+            mulitpackager.run()
+            self.assertIn("Uploading package 1/2", tc.out)
+            self.assertIn("Uploading package 2/2", tc.out)
+            self.assertIn("OLD", tc.out)
+            self.assertIn("Removing outdated packages for 'lib/1.0@user/testing'", tc.out)

--- a/cpt/test/unit/eraser_test.py
+++ b/cpt/test/unit/eraser_test.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+import unittest
+
+from collections import namedtuple
+from conans.test.utils.tools import TestBufferConanOutput
+from cpt.eraser import Eraser
+from cpt.printer import Printer
+from cpt.test.unit.packager_test import MockConanAPI
+
+
+class AuthTest(unittest.TestCase):
+
+    def setUp(self):
+        self.conan_api = MockConanAPI()
+        self.output = TestBufferConanOutput()
+        self.printer = Printer(self.output.write)
+
+    def test_invalid_remote(self):
+        eraser = Eraser(self.conan_api, None, None, self.printer, True)
+        eraser.remove_outdated_packages("foo/0.1.0@user/channel")
+        self.assertIn("Remove outdated skipped, no remote available", self.output)
+        self.assertFalse(self.conan_api.calls)
+
+    def test_invalid_authentication(self):
+        FakeRemoteManager = namedtuple("FakeRemoteManager", "upload_remote_name")
+        remote_manager = FakeRemoteManager(upload_remote_name="default")
+        eraser = Eraser(self.conan_api, remote_manager, None, self.printer, True)
+        eraser.remove_outdated_packages("foo/0.1.0@user/channel")
+        self.assertIn("Remove outdated skipped, credentials for remote 'default' not available", self.output)
+        self.assertFalse(self.conan_api.calls)


### PR DESCRIPTION
The new option will run conan `remove <ref> -r <remote> -f --outdated` after to upload a package.

Changelog: Feature: Remove outdated package after to upload (#282)

closes #282 

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan-package-tools/blob/develop/.github/CONTRIBUTING.md).
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008) style guides for Python code.
