### PR TITLE
Skip check credentials is boolean (#355)

### DIFF
--- a/cpt/packager.py
+++ b/cpt/packager.py
@@ -124,8 +124,7 @@ class ConanMultiPackager(object):
         if not self.username:
             raise Exception("Instance ConanMultiPackage with 'username' parameter or use "
                             "CONAN_USERNAME env variable")
-        self.skip_check_credentials = skip_check_credentials or \
-                                      os.getenv("CONAN_SKIP_CHECK_CREDENTIALS", False)
+        self.skip_check_credentials = skip_check_credentials or get_bool_from_env("CONAN_SKIP_CHECK_CREDENTIALS")
 
         self.auth_manager = AuthManager(self.conan_api, self.printer, login_username, password,
                                         default_username=self.username,

--- a/cpt/test/integration/upload_test.py
+++ b/cpt/test/integration/upload_test.py
@@ -94,6 +94,7 @@ class Pkg(ConanFile):
                                     ci_manager=self.ci_manager,
                                     upload="https://api.bintray.com/conan/conan-community/conan")
             mp.run()  # No builds to upload so no raises
+            self.assertNotIn("Wrong user or password", self.output)
 
     def test_existing_upload_repo(self):
         self.api.remote_add("my_upload_repo", "https://api.bintray.com/conan/conan-community/conan")


### PR DESCRIPTION
Changelog: Fix: Parse the env var CONAN_SKIP_CHECK_CREDENTIALS as boolean (#355)
fixes #355

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan-package-tools/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008) style guides for Python code.
