### PR TITLE
#361 Upload package with revisions

### DIFF
--- a/cpt/runner.py
+++ b/cpt/runner.py
@@ -4,6 +4,7 @@ from collections import namedtuple
 
 from conans import tools, __version__ as client_version
 from conans.model.version import Version
+from conans.model.ref import ConanFileReference
 
 from cpt import __version__ as package_tools_version
 from cpt.config import ConfigManager
@@ -113,7 +114,9 @@ class CreateRunner(object):
                             return
                         for installed in r['installed']:
                             reference = installed["recipe"]["id"]
-                            if ((str(self._reference) in reference) or \
+                            if client_version >= Version("1.10.0"):
+                                reference = str(ConanFileReference.loads(installed["recipe"]["id"]).copy_clear_rev())
+                            if ((reference == str(self._reference)) or \
                                (reference in self._upload_dependencies) or \
                                ("all" in self._upload_dependencies)) and \
                                installed['packages']:

--- a/cpt/runner.py
+++ b/cpt/runner.py
@@ -113,7 +113,7 @@ class CreateRunner(object):
                             return
                         for installed in r['installed']:
                             reference = installed["recipe"]["id"]
-                            if ((reference == str(self._reference)) or \
+                            if ((str(self._reference) in reference) or \
                                (reference in self._upload_dependencies) or \
                                ("all" in self._upload_dependencies)) and \
                                installed['packages']:

--- a/cpt/test/test_client/upload_checks_test.py
+++ b/cpt/test/test_client/upload_checks_test.py
@@ -110,7 +110,7 @@ class Pkg(ConanFile):
         # Upload only the recipe
         with environment_append({"CONAN_UPLOAD": ts.fake_url, "CONAN_LOGIN_USERNAME": "user",
                                 "CONAN_PASSWORD": "password", "CONAN_USERNAME": "user",
-                                "CONAN_UPLOAD_ONLY_RECIPE": "TRUE"}):
+                                "CONAN_UPLOAD_ONLY_RECIPE": "TRUE", "CONAN_CHANNEL": "mychannel"}):
             mulitpackager = get_patched_multipackager(tc, exclude_vcvars_precommand=True)
             mulitpackager.add({}, {"shared": True})
             mulitpackager.add({}, {"shared": False})
@@ -125,7 +125,7 @@ class Pkg(ConanFile):
         # Re-use cache the upload the binary packages
         with environment_append({"CONAN_UPLOAD": ts.fake_url, "CONAN_LOGIN_USERNAME": "user",
                                 "CONAN_PASSWORD": "password", "CONAN_USERNAME": "user",
-                                "CONAN_UPLOAD_ONLY_RECIPE": "FALSE"}):
+                                "CONAN_UPLOAD_ONLY_RECIPE": "FALSE", "CONAN_CHANNEL": "mychannel"}):
             mulitpackager = get_patched_multipackager(tc, exclude_vcvars_precommand=True)
             mulitpackager.add({}, {"shared": True})
             mulitpackager.add({}, {"shared": False})
@@ -144,7 +144,8 @@ class Pkg(ConanFile):
 
         # Upload only the recipe
         with environment_append({"CONAN_UPLOAD": ts.fake_url, "CONAN_LOGIN_USERNAME": "user",
-                                "CONAN_PASSWORD": "password", "CONAN_USERNAME": "user"}):
+                                "CONAN_PASSWORD": "password", "CONAN_USERNAME": "user",
+                                "CONAN_CHANNEL": "mychannel"}):
             mulitpackager = get_patched_multipackager(tc, exclude_vcvars_precommand=True,
                                                       upload_only_recipe=True)
             mulitpackager.add({}, {"shared": True})
@@ -159,7 +160,8 @@ class Pkg(ConanFile):
 
         # Re-use cache the upload the binary packages
         with environment_append({"CONAN_UPLOAD": ts.fake_url, "CONAN_LOGIN_USERNAME": "user",
-                                "CONAN_PASSWORD": "password", "CONAN_USERNAME": "user"}):
+                                "CONAN_PASSWORD": "password", "CONAN_USERNAME": "user",
+                                "CONAN_CHANNEL": "mychannel"}):
             mulitpackager = get_patched_multipackager(tc, exclude_vcvars_precommand=True,
                                                       upload_only_recipe=False)
             mulitpackager.add({}, {"shared": True})
@@ -171,6 +173,23 @@ class Pkg(ConanFile):
             self.assertIn("Recipe is up to date, upload skipped", tc.out)
             self.assertIn("Uploading package 1/2", tc.out)
             self.assertIn("Uploading package 2/2", tc.out)
+
+    def test_upload_package_revisions(self):
+        ts = TestServer(users={"user": "password"})
+        tc = TestClient(servers={"default": ts}, users={"default": [("user", "password")]})
+        tc.save({"conanfile.py": self.conanfile})
+        with environment_append({"CONAN_UPLOAD": ts.fake_url, "CONAN_LOGIN_USERNAME": "user",
+                                 "CONAN_PASSWORD": "password", "CONAN_USERNAME": "user",
+                                 "CONAN_REVISIONS_ENABLED": "1"}):
+            mulitpackager = get_patched_multipackager(tc, exclude_vcvars_precommand=True)
+            mulitpackager.add({}, {"shared": True})
+            mulitpackager.add({}, {"shared": False})
+            mulitpackager.run()
+            self.assertNotIn("Skipping upload for 5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9", tc.out)
+            self.assertNotIn("Skipping upload for 2a623e3082a38f90cd2c3d12081161412de331b0", tc.out)
+            self.assertIn("Uploading package 1/2", tc.out)
+            self.assertIn("Uploading package 2/2", tc.out)
+            self.assertIn("HALLO", tc.out)
 
 class UploadDependenciesTest(unittest.TestCase):
 


### PR DESCRIPTION
Package reference passed to be created is not the same retrieved from package id when the package is built.

    "foo/0.1@bar/testing" != "foo/0.1@bar/testing#<hash>"

Changelog: Bugfix: Fix Package Revisions support (#361)

fixes: #361

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan-package-tools/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008) style guides for Python code.
