### PR TITLE
Fix broken tests for release 0.25.0

### DIFF
--- a/cpt/packager.py
+++ b/cpt/packager.py
@@ -247,12 +247,12 @@ class ConanMultiPackager(object):
             # With LCOW, Docker doesn't respect USER directive in dockerfile yet
             self.lcow_user_workaround = "sudo su conan && "
 
-        self.exclude_vcvars_precommand = (exclude_vcvars_precommand or
-                                          os.getenv("CONAN_EXCLUDE_VCVARS_PRECOMMAND", False))
-        self._docker_image_skip_update = (docker_image_skip_update or
-                                          os.getenv("CONAN_DOCKER_IMAGE_SKIP_UPDATE", False))
-        self._docker_image_skip_pull = (docker_image_skip_pull or
-                                        os.getenv("CONAN_DOCKER_IMAGE_SKIP_PULL", False))
+        self.exclude_vcvars_precommand = exclude_vcvars_precommand or \
+                                          get_bool_from_env("CONAN_EXCLUDE_VCVARS_PRECOMMAND")
+        self._docker_image_skip_update = docker_image_skip_update or \
+                                          get_bool_from_env("CONAN_DOCKER_IMAGE_SKIP_UPDATE")
+        self._docker_image_skip_pull = docker_image_skip_pull or \
+                                        get_bool_from_env("CONAN_DOCKER_IMAGE_SKIP_PULL")
 
         self.runner = runner or os.system
         self.output_runner = ConanOutputRunner()

--- a/cpt/runner.py
+++ b/cpt/runner.py
@@ -115,7 +115,8 @@ class CreateRunner(object):
                         for installed in r['installed']:
                             reference = installed["recipe"]["id"]
                             if client_version >= Version("1.10.0"):
-                                reference = str(ConanFileReference.loads(installed["recipe"]["id"]).copy_clear_rev())
+                                reference = ConanFileReference.loads(reference)
+                                reference = str(reference.copy_clear_rev())
                             if ((reference == str(self._reference)) or \
                                (reference in self._upload_dependencies) or \
                                ("all" in self._upload_dependencies)) and \

--- a/cpt/test/integration/base.py
+++ b/cpt/test/integration/base.py
@@ -46,18 +46,6 @@ class BaseTest(unittest.TestCase):
         self.api, self.client_cache, _ = ConanAPIV1.factory()
         print("Testing with Conan Folder=%s" % self.client_cache.conan_folder)
 
-    def deploy_pip(self):
-        if os.getenv("PYPI_PASSWORD", None):
-            conf_path = os.path.expanduser("~/.pypirc")
-            if not os.path.exists(conf_path):
-                tools.save(conf_path, pypi_template)
-            ret = os.system("cd %s && ls && python setup.py sdist upload -r pypi_testing_conan" % self.old_folder)
-            if ret != 0:
-                raise Exception("Failed publishing conan package tools")
-            self.output.write("Deployed pip package")
-        else:
-            raise Exception("Skipped deploy of pip package!")
-
     def tearDown(self):
         os.chdir(self.old_folder)
         os.environ.clear()

--- a/cpt/test/integration/docker_test.py
+++ b/cpt/test/integration/docker_test.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import time
+import subprocess
 import unittest
 
 from conans import __version__ as client_version
@@ -21,11 +22,19 @@ def is_linux_and_have_docker():
 
 class DockerTest(BaseTest):
 
+    CONAN_SERVER_ADDRESS = "http://0.0.0.0:9300"
+
+    def setUp(self):
+        super(DockerTest, self).setUp()
+        self.server_process = subprocess.Popen("conan_server")
+        time.sleep(3)
+
+    def tearDown(self):
+        self.server_process.kill()
+        super(DockerTest, self).tearDown()
+
     @unittest.skipUnless(is_linux_and_have_docker(), "Requires Linux and Docker")
     def test_docker(self):
-        if not os.getenv("PYPI_PASSWORD", None):
-            return
-        self.deploy_pip()
         ci_manager = MockCIManager()
         unique_ref = "zlib/%s" % str(time.time())
         conanfile = """from conans import ConanFile
@@ -35,18 +44,18 @@ class Pkg(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
 
 """
+
         self.save_conanfile(conanfile)
-        the_version = version.replace("-", ".")  # Canonical name for artifactory repo
-        pip = "--extra-index-url %s/simple conan-package-tools==%s " % (PYPI_TESTING_REPO, the_version)
-        with tools.environment_append({"CONAN_USE_DOCKER": "1",
+        with tools.environment_append({"CONAN_DOCKER_RUN_OPTIONS": "--network=host -v{}:/tmp/cpt".format(self.old_folder),
+                                       "CONAN_DOCKER_ENTRY_SCRIPT": "pip install -U /tmp/cpt",
+                                       "CONAN_USE_DOCKER": "1",
                                        "CONAN_DOCKER_USE_SUDO": "1",
-                                       "CONAN_PIP_PACKAGE": pip,
-                                       "CONAN_LOGIN_USERNAME": CONAN_LOGIN_UPLOAD,
-                                       "CONAN_USERNAME": "lasote",
-                                       "CONAN_UPLOAD": CONAN_UPLOAD_URL,
-                                       "CONAN_PASSWORD": CONAN_UPLOAD_PASSWORD,
-                                       "CONAN_CONFIG_URL": "https://conan.jfrog.io/conan/"
-                                                           "testing_files/empty_zip.zip"}):
+                                       "CONAN_DOCKER_IMAGE_SKIP_UPDATE": "TRUE",
+                                       "CONAN_LOGIN_USERNAME": "demo",
+                                       "CONAN_USERNAME": "demo",
+                                       "CONAN_UPLOAD": DockerTest.CONAN_SERVER_ADDRESS,
+                                       "CONAN_PASSWORD": "demo"}):
+
             self.packager = ConanMultiPackager(channel="mychannel",
                                                gcc_versions=["6"],
                                                archs=["x86", "x86_64"],
@@ -57,7 +66,7 @@ class Pkg(ConanFile):
             self.packager.run()
 
         search_pattern = "%s*" % unique_ref
-        ref = ConanFileReference.loads("%s@lasote/mychannel" % unique_ref)
+        ref = ConanFileReference.loads("%s@demo/mychannel" % unique_ref)
 
         # Remove from remote
         if Version(client_version) < Version("1.7"):
@@ -76,25 +85,27 @@ class Pkg(ConanFile):
                 ref = repr(ref)
             packages = self.api.search_packages(ref, remote_name="upload_repo")["results"][0]["items"][0]["packages"]
             self.assertEquals(len(packages), 2)
-            self.api.authenticate(name=CONAN_LOGIN_UPLOAD, password=CONAN_UPLOAD_PASSWORD,
+            self.api.authenticate(name="demo", password="demo",
                                   remote_name="upload_repo")
             self.api.remove(search_pattern, remote_name="upload_repo", force=True)
             self.assertEquals(self.api.search_recipes(search_pattern)["results"], [])
 
         # Try upload only when stable, shouldn't upload anything
-        with tools.environment_append({"CONAN_USE_DOCKER": "1",
+        with tools.environment_append({"CONAN_DOCKER_RUN_OPTIONS": "--network=host -v{}:/tmp/cpt".format(self.old_folder),
+                                       "CONAN_DOCKER_ENTRY_SCRIPT": "pip install -U /tmp/cpt",
+                                       "CONAN_USE_DOCKER": "1",
                                        "CONAN_DOCKER_USE_SUDO": "1",
-                                       "CONAN_PIP_PACKAGE": pip,
-                                       "CONAN_LOGIN_USERNAME": CONAN_LOGIN_UPLOAD,
-                                       "CONAN_USERNAME": "lasote",
-                                       "CONAN_PASSWORD": CONAN_UPLOAD_PASSWORD,
+                                       "CONAN_LOGIN_USERNAME": "demo",
+                                       "CONAN_USERNAME": "demo",
+                                       "CONAN_PASSWORD": "demo",
+                                       "CONAN_DOCKER_IMAGE_SKIP_UPDATE": "TRUE",
                                        "CONAN_UPLOAD_ONLY_WHEN_STABLE": "1"}):
             self.packager = ConanMultiPackager(channel="mychannel",
                                                gcc_versions=["6"],
                                                archs=["x86", "x86_64"],
                                                build_types=["Release"],
                                                reference=unique_ref,
-                                               upload=CONAN_UPLOAD_URL,
+                                               upload=DockerTest.CONAN_SERVER_ADDRESS,
                                                ci_manager=ci_manager)
             self.packager.add_common_builds()
             self.packager.run()
@@ -107,7 +118,6 @@ class Pkg(ConanFile):
             results = self.api.search_recipes(search_pattern, remote_name="upload_repo")["results"]
             self.assertEquals(len(results), 0)
             self.api.remove(search_pattern, remote_name="upload_repo", force=True)
-
 
     @unittest.skipUnless(is_linux_and_have_docker(), "Requires Linux and Docker")
     def test_docker_run_options(self):
@@ -122,11 +132,13 @@ class Pkg(ConanFile):
 """
         self.save_conanfile(conanfile)
         # Validate by Environemnt Variable
-        with tools.environment_append({"CONAN_USERNAME": "bar",
+        with tools.environment_append({"CONAN_DOCKER_ENTRY_SCRIPT": "pip install -U /tmp/cpt",
+                                       "CONAN_USERNAME": "bar",
                                        "CONAN_DOCKER_IMAGE": "conanio/gcc8",
                                        "CONAN_DOCKER_USE_SUDO": "0",
                                        "CONAN_REFERENCE": "foo/0.0.1@bar/testing",
-                                       "CONAN_DOCKER_RUN_OPTIONS": "--network=host, --add-host=google.com:8.8.8.8"
+                                       "CONAN_DOCKER_RUN_OPTIONS": "--network=host, --add-host=google.com:8.8.8.8 -v{}:/tmp/cpt".format(self.old_folder),
+                                       "CONAN_DOCKER_IMAGE_SKIP_UPDATE": "TRUE"
                                        }):
             self.packager = ConanMultiPackager(gcc_versions=["8"],
                                                archs=["x86_64"],
@@ -134,7 +146,7 @@ class Pkg(ConanFile):
                                                out=self.output.write)
             self.packager.add({})
             self.packager.run()
-            self.assertIn("--network=host --add-host=google.com:8.8.8.8  conanio/gcc8", self.output)
+            self.assertIn("--network=host --add-host=google.com:8.8.8.8 -v", self.output)
 
         # Validate by parameter
         with tools.environment_append({"CONAN_USERNAME": "bar",
@@ -146,7 +158,9 @@ class Pkg(ConanFile):
             self.packager = ConanMultiPackager(gcc_versions=["8"],
                                                archs=["x86_64"],
                                                build_types=["Release"],
-                                               docker_run_options="--cpus=1",
+                                               docker_run_options="--network=host -v{}:/tmp/cpt --cpus=1".format(self.old_folder) ,
+                                               docker_entry_script="pip install -U /tmp/cpt",
+                                               docker_image_skip_update=True,
                                                out=self.output.write)
             self.packager.add({})
             self.packager.run()

--- a/cpt/test/test_client/upload_checks_test.py
+++ b/cpt/test/test_client/upload_checks_test.py
@@ -4,6 +4,7 @@ import zipfile
 
 from conans.client.tools import environment_append
 from conans.test.utils.tools import TestClient, TestServer
+from cpt.test.unit.utils import MockCIManager
 
 from cpt.test.test_client.tools import get_patched_multipackager
 
@@ -20,6 +21,8 @@ class Pkg(ConanFile):
     def build(self):
         self.output.warn("HALLO")
 """
+    def setUp(self):
+        self._ci_manager = MockCIManager()
 
     def test_dont_upload_non_built_packages(self):
 
@@ -111,7 +114,8 @@ class Pkg(ConanFile):
         with environment_append({"CONAN_UPLOAD": ts.fake_url, "CONAN_LOGIN_USERNAME": "user",
                                 "CONAN_PASSWORD": "password", "CONAN_USERNAME": "user",
                                 "CONAN_UPLOAD_ONLY_RECIPE": "TRUE", "CONAN_CHANNEL": "mychannel"}):
-            mulitpackager = get_patched_multipackager(tc, exclude_vcvars_precommand=True)
+            mulitpackager = get_patched_multipackager(tc, exclude_vcvars_precommand=True,
+                                                      ci_manager=self._ci_manager)
             mulitpackager.add({}, {"shared": True})
             mulitpackager.add({}, {"shared": False})
             mulitpackager.run()
@@ -126,7 +130,8 @@ class Pkg(ConanFile):
         with environment_append({"CONAN_UPLOAD": ts.fake_url, "CONAN_LOGIN_USERNAME": "user",
                                 "CONAN_PASSWORD": "password", "CONAN_USERNAME": "user",
                                 "CONAN_UPLOAD_ONLY_RECIPE": "FALSE", "CONAN_CHANNEL": "mychannel"}):
-            mulitpackager = get_patched_multipackager(tc, exclude_vcvars_precommand=True)
+            mulitpackager = get_patched_multipackager(tc, exclude_vcvars_precommand=True,
+                                                      ci_manager=self._ci_manager)
             mulitpackager.add({}, {"shared": True})
             mulitpackager.add({}, {"shared": False})
             mulitpackager.run()
@@ -147,7 +152,8 @@ class Pkg(ConanFile):
                                 "CONAN_PASSWORD": "password", "CONAN_USERNAME": "user",
                                 "CONAN_CHANNEL": "mychannel"}):
             mulitpackager = get_patched_multipackager(tc, exclude_vcvars_precommand=True,
-                                                      upload_only_recipe=True)
+                                                      upload_only_recipe=True,
+                                                      ci_manager=self._ci_manager)
             mulitpackager.add({}, {"shared": True})
             mulitpackager.add({}, {"shared": False})
             mulitpackager.run()
@@ -163,7 +169,8 @@ class Pkg(ConanFile):
                                 "CONAN_PASSWORD": "password", "CONAN_USERNAME": "user",
                                 "CONAN_CHANNEL": "mychannel"}):
             mulitpackager = get_patched_multipackager(tc, exclude_vcvars_precommand=True,
-                                                      upload_only_recipe=False)
+                                                      upload_only_recipe=False,
+                                                      ci_manager=self._ci_manager)
             mulitpackager.add({}, {"shared": True})
             mulitpackager.add({}, {"shared": False})
             mulitpackager.run()
@@ -181,7 +188,8 @@ class Pkg(ConanFile):
         with environment_append({"CONAN_UPLOAD": ts.fake_url, "CONAN_LOGIN_USERNAME": "user",
                                  "CONAN_PASSWORD": "password", "CONAN_USERNAME": "user",
                                  "CONAN_REVISIONS_ENABLED": "1"}):
-            mulitpackager = get_patched_multipackager(tc, exclude_vcvars_precommand=True)
+            mulitpackager = get_patched_multipackager(tc, exclude_vcvars_precommand=True,
+                                                      ci_manager=self._ci_manager)
             mulitpackager.add({}, {"shared": True})
             mulitpackager.add({}, {"shared": False})
             mulitpackager.run()
@@ -190,6 +198,7 @@ class Pkg(ConanFile):
             self.assertIn("Uploading package 1/2", tc.out)
             self.assertIn("Uploading package 2/2", tc.out)
             self.assertIn("HALLO", tc.out)
+
 
 class UploadDependenciesTest(unittest.TestCase):
 
@@ -224,6 +233,7 @@ class Pkg(ConanFile):
 """
 
     def setUp(self):
+        self._ci_manager = MockCIManager()
         self._server = TestServer(users={"user": "password"},
                                   write_permissions=[("bar/0.1.0@foo/stable", "user"),
                                                      ("foo/1.0.0@bar/testing", "user")])
@@ -244,7 +254,8 @@ class Pkg(ConanFile):
             mulitpackager = get_patched_multipackager(self._client, username="user",
                                                       channel="testing",
                                                       build_policy="missing",
-                                                      exclude_vcvars_precommand=True)
+                                                      exclude_vcvars_precommand=True,
+                                                      ci_manager=self._ci_manager)
             mulitpackager.add({}, {})
             mulitpackager.run()
 
@@ -279,7 +290,8 @@ class Pkg(ConanFile):
             mulitpackager = get_patched_multipackager(self._client, username="user",
                                                       channel="testing",
                                                       build_policy="missing",
-                                                      exclude_vcvars_precommand=True)
+                                                      exclude_vcvars_precommand=True,
+                                                      ci_manager=self._ci_manager)
             mulitpackager.add({}, {})
             mulitpackager.run()
 
@@ -304,7 +316,8 @@ class Pkg(ConanFile):
             mulitpackager = get_patched_multipackager(self._client, username="user",
                                                       channel="testing",
                                                       build_policy="missing",
-                                                      exclude_vcvars_precommand=True)
+                                                      exclude_vcvars_precommand=True,
+                                                      ci_manager=self._ci_manager)
             mulitpackager.add({}, {})
             mulitpackager.run()
 

--- a/cpt/test/unit/utils.py
+++ b/cpt/test/unit/utils.py
@@ -3,6 +3,7 @@ from collections import namedtuple
 
 from conans import __version__ as conan_version
 from conans import tools
+from conans.model.ref import ConanFileReference
 from conans.test.utils.test_files import temp_folder
 from conans.util.files import save
 from conans.model.version import Version
@@ -39,18 +40,20 @@ class MockConanAPI(object):
         self._client_cache = self._cache = MockConanCache()
 
     def create(self, *args, **kwargs):
+        reference = ConanFileReference(kwargs["name"], kwargs["version"], kwargs["user"], kwargs["channel"])
         self.calls.append(Action("create", args, kwargs))
         return {
             "installed": [
                {
                   "packages": [
                      {
-                        "id": "227fb0ea22f4797212e72ba94ea89c7b3fbc2a0c"
+                        "id": "227fb0ea22f4797212e72ba94ea89c7b3fbc2a0c",
+                        "built": True
                      }
                   ],
                   "recipe": {
-                     "id": kwargs["name"]
-                  }
+                     "id": str(reference)
+                  },
                }]}
 
     def create_profile(self, *args, **kwargs):


### PR DESCRIPTION
Release branch is fragile, only specific tests are able to run, or even CPT behavior could change during the tests.

Since `release/*` is a pattern for stable branch, many tests will fail when the channel is no specific the and CI manager is not mocked. Otherwise, CPT will recognize the current branch as stable and will change all package channel names during the tests.

About the package with the "name" only. It was because we use ConanAPIMock, and it only returns the package name, which represents conan_api.create returns. A typical return is:

```
{'recipe': {'id': 'foo/0.1@uilianries/testing', 'downloaded': False, 'exported': True, 'error': None, 'remote': None, 'time': datetime.datetime(2019, 3, 28, 19, 34, 35, 868478), 'dependency': False, 'name': 'foo', 'version': '0.1', 'user': 'uilianries', 'channel': 'testing'}, 'packages': [{'id': 'b6c337ae40a7acc0472113db7b56e3585b936000', 'downloaded': False, 'exported': False, 'error': None, 'remote': None, 'time': datetime.datetime(2019, 3, 28, 19, 34, 38, 524986), 'built': True, 'cpp_info': {'includedirs': ['include'], 'libdirs': ['lib'], 'resdirs': ['res'], 'bindirs': ['bin'], 'builddirs': [''], 'libs': ['hello'], 'rootpath': '/home/uilian/.conan/data/foo/0.1/uilianries/testing/package/b6c337ae40a7acc0472113db7b56e3585b936000', 'version': '0.1', 'description': '<Description of Foo here>', 'filter_empty': True}}]}
``` 

But since we don't to use all those fields, I only updated the reference and built.

Changelog: Omit

- [ ] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan-package-tools/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008) style guides for Python code.
