### PR TITLE
fix crash when using run_in_docker

### DIFF
--- a/cpt/runner.py
+++ b/cpt/runner.py
@@ -37,7 +37,7 @@ class CreateRunner(object):
         self._conanfile = conanfile
         self._upload_dependencies = upload_dependencies.split(",") if \
                                     isinstance(upload_dependencies, str) else \
-                                    upload_dependencies
+                                    upload_dependencies or []
 
         patch_default_base_profile(conan_api, profile_abs_path)
 


### PR DESCRIPTION
Avoids iterating over self._upload_dependencies equal to None

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan-package-tools/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008) style guides for Python code.
