### PR TITLE
Retry authentication

### DIFF
--- a/cpt/packager.py
+++ b/cpt/packager.py
@@ -132,7 +132,8 @@ class ConanMultiPackager(object):
 
         self.auth_manager = AuthManager(self.conan_api, self.printer, login_username, password,
                                         default_username=self.username,
-                                        skip_check_credentials=self.skip_check_credentials)
+                                        skip_check_credentials=self.skip_check_credentials,
+                                        retry=self.upload_retry)
 
         # Upload related variables
         self.upload_retry = upload_retry or os.getenv("CONAN_UPLOAD_RETRY", 3)

--- a/cpt/run_in_docker.py
+++ b/cpt/run_in_docker.py
@@ -19,9 +19,9 @@ def run():
 
     remotes_manager = RemotesManager(conan_api, printer)
     default_username = os.getenv("CONAN_USERNAME")
-    auth_manager = AuthManager(conan_api, printer, default_username=default_username)
-
     upload_retry = os.getenv("CPT_UPLOAD_RETRY")
+    auth_manager = AuthManager(conan_api, printer, default_username=default_username, retry=upload_retry)
+
     upload_only_recipe = os.getenv("CPT_UPLOAD_ONLY_RECIPE")
     uploader = Uploader(conan_api, remotes_manager, auth_manager, printer, upload_retry)
     build_policy = unscape_env(os.getenv("CPT_BUILD_POLICY"))


### PR DESCRIPTION
Hi!

As we can see [here](https://ci.appveyor.com/project/ConanCIintegration/conan-openssl/builds/24895637/job/x7697tjf26k60kbd#L5356) OpenSSL package wasn't uploaded because Conan could not login due a connection error.

When uploading a package, CPT uses retry=3 by default, there is no retry for authentication.

Related issue: https://github.com/conan-io/conan/issues/5262

Changelog: Feature: Retry remote authentication

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan-package-tools/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008) style guides for Python code.
