### PR TITLE
Fix Conan API compatibility (#385)

### DIFF
--- a/cpt/packager.py
+++ b/cpt/packager.py
@@ -29,6 +29,13 @@ def load_cf_class(path, conan_api):
     if Version(client_version) < Version("1.7.0"):
         from conans.client.loader_parse import load_conanfile_class
         return load_conanfile_class(path)
+    elif Version(client_version) < Version("1.14.0"):
+        return conan_api._loader.load_class(path)
+    elif Version(client_version) < Version("1.15.0"):
+        remotes = conan_api._cache.registry.remotes.list
+        for remote in remotes:
+            conan_api.python_requires.enable_remotes(remote_name=remote)
+        return conan_api._loader.load_class(path)
     elif Version(client_version) < Version("1.16.0"):
         remotes = conan_api._cache.registry.load_remotes()
         conan_api.python_requires.enable_remotes(remotes=remotes)


### PR DESCRIPTION
Verify Conan version x Python Requires feature

Changelog: Fix: Support Conan 1.12 - 1.14

fixes #385 

@lasote I could add new tests in our CI, but it will increase our buiding time. I could add new Conan versions (1.12, 1.14) in tox file.

- [x] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan-package-tools/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008) style guides for Python code.
