### PR TITLE
Add support for Conan 1.20.0-dev

### DIFF
--- a/cpt/packager.py
+++ b/cpt/packager.py
@@ -49,8 +49,10 @@ def load_cf_class(path, conan_api):
             conan_api.create_app()
         remotes = conan_api.app.cache.registry.load_remotes()
         conan_api.app.python_requires.enable_remotes(remotes=remotes)
-        return conan_api.app.loader.load_class(path)
-
+        if Version(client_version) < Version("1.20.0"):
+            return conan_api.app.loader.load_class(path)
+        else:
+            return conan_api.app.loader.load_basic(path)
 
 class PlatformInfo(object):
     """Easy mockable for testing"""

--- a/cpt/requirements_test.txt
+++ b/cpt/requirements_test.txt
@@ -1,5 +1,5 @@
 nose>=1.3.7
-nose_parameterized>=0.5.0, <0.6.0
+parameterized>=0.5.0, <0.8.0
 mock>=1.3.0, <1.4.0
 WebTest>=2.0.18, <2.1.0
 tox==3.7.0


### PR DESCRIPTION
After Conana 1.19.0, the method `load_class` has been replaced by `basic_load`.
Also, `nose_parameterized` is deprecated, according pypi page. The project `parameterized` should be used instead.

Changelog: Fix: Support Conan 1.20

- [ ] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan-package-tools/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008) style guides for Python code.
