### PR TITLE
fixup indentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ Or you can directly iterate the builds to do any change. EX: Remove the GCC 4.6 
         filtered_builds = []
         for settings, options, env_vars, build_requires, reference in builder.items:
             if settings["compiler.version"] != "4.6" and settings["build_type"] != "Debug":
-                 filtered_builds.append([settings, options, env_vars, build_requires])
+                 filtered_builds.append([settings, options, env_vars, build_requires, reference])
         builder.builds = filtered_builds
         builder.run()
 

--- a/cpt/builds_generator.py
+++ b/cpt/builds_generator.py
@@ -401,7 +401,7 @@ def get_linux_gcc_builds(gcc_versions, archs, shared_option_name, pure_c, build_
                         else:
                             ret.append(get_build("gcc", arch, build_type_it, gcc_version, None,
                                                  None, options, reference))
-        return ret
+    return ret
 
 
 def get_linux_clang_builds(clang_versions, archs, shared_option_name, pure_c, build_types, cppstds,


### PR DESCRIPTION
without  this, clang builds fail with error
AttributeError: 'NoneType' object has no attribute 'extend'

Changelog: Bugfix: Fix Clang builds 

- [ ] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan-package-tools/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008) style guides for Python code.
