### PR TITLE
Support build policy ALL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1072,6 +1072,7 @@ Using **CONAN_CLANG_VERSIONS** env variable in Travis ci or Appveyor:
     - "missing": Build only missing packages.
     - "outdated": Build only missing or if the available package is not built with the current recipe. Useful to upload new configurations, e.j packages for a new compiler without
       rebuild all packages.
+    - "all": Build all requirements.
 - **test_folder**: Custom test folder consumed by Conan create, e.j .conan/test_package
 - **conanfile**: Custom conanfile consumed by Conan create. e.j. conanfile.py
 - **config_url**: Conan config URL be installed before to build e.j https://github.com/bincrafters/conan-config.git

--- a/cpt/ci_manager.py
+++ b/cpt/ci_manager.py
@@ -68,7 +68,7 @@ class CIManager(object):
         matches = prog.match(msg)
         if matches:
             build_policy = matches.groups()[0]
-            if build_policy not in ("never", "outdated", "missing"):
+            if build_policy not in ("never", "outdated", "missing", "all"):
                 raise Exception("Invalid build policy, valid values: never, outdated, missing")
             return build_policy
         return None

--- a/cpt/packager.py
+++ b/cpt/packager.py
@@ -237,7 +237,7 @@ class ConanMultiPackager(object):
                         os.getenv("CONAN_BUILD_POLICY", None))
 
         if build_policy:
-            if build_policy.lower() not in ("never", "outdated", "missing"):
+            if build_policy.lower() not in ("never", "outdated", "missing", "all"):
                 raise Exception("Invalid build policy, valid values: never, outdated, missing")
 
         self.build_policy = build_policy

--- a/cpt/runner.py
+++ b/cpt/runner.py
@@ -88,7 +88,7 @@ class CreateRunner(object):
                     name, version, user, channel, _ = self._reference
 
                 if self._build_policy:
-                    self._build_policy = [self._build_policy]
+                    self._build_policy = [] if self._build_policy == "all" else [self._build_policy]
                 # https://github.com/conan-io/conan-package-tools/issues/184
                 with tools.environment_append({"_CONAN_CREATE_COMMAND_": "1"}):
                     params = {"name": name, "version": version, "user": user,

--- a/cpt/test/unit/ci_manager_test.py
+++ b/cpt/test/unit/ci_manager_test.py
@@ -206,6 +206,13 @@ class CIManagerTest(unittest.TestCase):
             self.assertEquals(manager.get_commit_msg(), "This is a great commit "
                                                         "[build=outdated] End.")
 
+        with tools.environment_append({"TRAVIS": "1",
+                                       "TRAVIS_COMMIT_MESSAGE":
+                                           "This is a great commit [build=all] End."}):
+            manager = CIManager(self.printer)
+            self.assertEquals(manager.get_commit_build_policy(), "all")
+            self.assertEquals(manager.get_commit_msg(), "This is a great commit "
+                                                        "[build=all] End.")
         # Appveyor
         with tools.environment_append({"APPVEYOR": "1",
                                        "APPVEYOR_PULL_REQUEST_NUMBER": "1",

--- a/cpt/test/unit/packager_test.py
+++ b/cpt/test/unit/packager_test.py
@@ -652,21 +652,22 @@ class AppTest(unittest.TestCase):
         builder.run()
         self.assertEquals(["outdated"], self.conan_api.calls[-1].kwargs["build_modes"])
 
-        with tools.environment_append({"CONAN_BUILD_POLICY": "missing"}):
-            self.conan_api = MockConanAPI()
-            builder = ConanMultiPackager(username="pepe", channel="testing",
-                                         reference="Hello/0.1", password="password",
-                                         visual_versions=[], gcc_versions=[],
-                                         apple_clang_versions=[],
-                                         runner=self.runner,
-                                         conan_api=self.conan_api,
-                                         remotes="otherurl",
-                                         platform_info=platform_mock_for("Darwin"),
-                                         build_policy="missing",
-                                         ci_manager=self.ci_manager)
-            builder.add_common_builds()
-            builder.run()
-            self.assertEquals(["missing"], self.conan_api.calls[-1].kwargs["build_modes"])
+        for build_policy in ["missing", "all"]:
+            with tools.environment_append({"CONAN_BUILD_POLICY": build_policy}):
+                self.conan_api = MockConanAPI()
+                builder = ConanMultiPackager(username="pepe", channel="testing",
+                                             reference="Hello/0.1", password="password",
+                                             visual_versions=[], gcc_versions=[],
+                                             apple_clang_versions=[],
+                                             runner=self.runner,
+                                             conan_api=self.conan_api,
+                                             remotes="otherurl",
+                                             platform_info=platform_mock_for("Darwin"),
+                                             build_policy="missing",
+                                             ci_manager=self.ci_manager)
+                builder.add_common_builds()
+                builder.run()
+                self.assertEquals([build_policy], self.conan_api.calls[-1].kwargs["build_modes"])
 
     def test_test_folder(self):
         builder = ConanMultiPackager(username="pepe", channel="testing",

--- a/cpt/test/unit/packager_test.py
+++ b/cpt/test/unit/packager_test.py
@@ -652,7 +652,7 @@ class AppTest(unittest.TestCase):
         builder.run()
         self.assertEquals(["outdated"], self.conan_api.calls[-1].kwargs["build_modes"])
 
-        for build_policy in ["missing", "all"]:
+        for build_policy, expected in [("missing", ["missing"]), ("all",[])]:
             with tools.environment_append({"CONAN_BUILD_POLICY": build_policy}):
                 self.conan_api = MockConanAPI()
                 builder = ConanMultiPackager(username="pepe", channel="testing",
@@ -667,7 +667,7 @@ class AppTest(unittest.TestCase):
                                              ci_manager=self.ci_manager)
                 builder.add_common_builds()
                 builder.run()
-                self.assertEquals([build_policy], self.conan_api.calls[-1].kwargs["build_modes"])
+                self.assertEquals(expected, self.conan_api.calls[-1].kwargs["build_modes"])
 
     def test_test_folder(self):
         builder = ConanMultiPackager(username="pepe", channel="testing",

--- a/cpt/test/unit/packager_test.py
+++ b/cpt/test/unit/packager_test.py
@@ -663,7 +663,7 @@ class AppTest(unittest.TestCase):
                                              conan_api=self.conan_api,
                                              remotes="otherurl",
                                              platform_info=platform_mock_for("Darwin"),
-                                             build_policy="missing",
+                                             build_policy=build_policy,
                                              ci_manager=self.ci_manager)
                 builder.add_common_builds()
                 builder.run()


### PR DESCRIPTION
Add new policy for building: `all`. The effect is the same as running `conan create . --build`, which means, build ALL requirements from sources.

Changelog: Feature: Build all requirements by passing the build_policy=all
close #436

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan-package-tools/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008) style guides for Python code.
