### PR TITLE
pass CONAN_USERNAME envvar to docker (#479)

### DIFF
--- a/cpt/runner.py
+++ b/cpt/runner.py
@@ -330,7 +330,7 @@ class DockerCreateRunner(object):
         ret["CPT_BASE_PROFILE"] = escape_env(self._base_profile_text)
         ret["CPT_BASE_PROFILE_NAME"] = escape_env(self._base_profile_name)
 
-        ret["CONAN_USERNAME"] = escape_env(self._reference.user)
+        ret["CONAN_USERNAME"] = escape_env(self._reference.user or ret.get("CONAN_USERNAME"))
         ret["CONAN_TEMP_TEST_FOLDER"] = "1"  # test package folder to a temp one
         ret["CPT_UPLOAD_ENABLED"] = self._upload
         ret["CPT_UPLOAD_RETRY"] = self._upload_retry


### PR DESCRIPTION
fixes #479 

Changelog: Fix: Fix empty username on Docker

Due to [`_noneize()`](https://github.com/conan-io/conan/blob/1.22.2/conans/model/ref.py#L24) being used during construction of [`ConanFileReference`](https://github.com/conan-io/conan/blob/1.22.2/conans/model/ref.py#L150), the `user` and `channel` parts of reference object are replaced from `'_'` to `None`.
Thus, when user provides `CONAN_USERNAME=_, CONAN_CHANNEL=_` for CPT to be forwarded to `docker run`, the username var was reset to `None`, causing Conan running inside docker to think that the user provided only one envvar.

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan-package-tools/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008) style guides for Python code.
