### PR TITLE
handle refs/heads/ in Github Actions branch names

### DIFF
--- a/cpt/ci_manager.py
+++ b/cpt/ci_manager.py
@@ -307,6 +307,8 @@ class GitHubActionsManager(GenericManager):
         branch = os.getenv("GITHUB_REF", None)
         if self.is_pull_request():
             branch = os.getenv("GITHUB_BASE_REF", "")
+        if branch.startswith("refs/heads/"):
+            branch = branch[11:]
         return branch
 
     def is_pull_request(self):

--- a/cpt/test/unit/ci_manager_test.py
+++ b/cpt/test/unit/ci_manager_test.py
@@ -198,12 +198,12 @@ class CIManagerTest(unittest.TestCase):
     def test_github_actions_instance(self):
         gha_env = {"GITHUB_ACTIONS": "true",
                    "GITHUB_SHA": "98e984eacf4e3dfea431c8850c8c181a08e8cf3d",
-                   "GITHUB_REF": "testing/5.6.5",
-                   "GITHUB_BASE_REF": "testing/5.6.5",
+                   "GITHUB_REF": "refs/heads/testing/5.6.5",
+                   "GITHUB_BASE_REF": "refs/heads/testing/5.6.5",
                    "GITHUB_EVENT_NAME": "push"}
         with tools.environment_append(gha_env):
             manager = CIManager(self.printer)
-            self.assertEquals(manager.get_branch(), gha_env["GITHUB_REF"])
+            self.assertEquals(manager.get_branch(), "testing/5.6.5")
             self.assertEquals(manager.get_commit_id(), gha_env["GITHUB_SHA"])
             self.assertEquals(manager.is_pull_request(), False)
 
@@ -289,5 +289,3 @@ class CIManagerTest(unittest.TestCase):
 
             self.assertEquals(os.getenv('CONAN_LOGIN_USERNAME'), "bamboo")
             self.assertEquals(os.getenv('CONAN_USER_VAR'), "foobar")
-
-

--- a/cpt/test/unit/ci_manager_test.py
+++ b/cpt/test/unit/ci_manager_test.py
@@ -198,12 +198,12 @@ class CIManagerTest(unittest.TestCase):
     def test_github_actions_instance(self):
         gha_env = {"GITHUB_ACTIONS": "true",
                    "GITHUB_SHA": "98e984eacf4e3dfea431c8850c8c181a08e8cf3d",
-                   "GITHUB_REF": "refs/heads/testing/5.6.5",
-                   "GITHUB_BASE_REF": "refs/heads/testing/5.6.5",
+                   "GITHUB_REF": "testing/5.6.5",
+                   "GITHUB_BASE_REF": "testing/5.6.5",
                    "GITHUB_EVENT_NAME": "push"}
         with tools.environment_append(gha_env):
             manager = CIManager(self.printer)
-            self.assertEquals(manager.get_branch(), "testing/5.6.5")
+            self.assertEquals(manager.get_branch(), gha_env["GITHUB_REF"])
             self.assertEquals(manager.get_commit_id(), gha_env["GITHUB_SHA"])
             self.assertEquals(manager.is_pull_request(), False)
 
@@ -217,6 +217,13 @@ class CIManagerTest(unittest.TestCase):
             self.assertEquals(manager.get_branch(), gha_env["GITHUB_BASE_REF"])
             self.assertEquals(manager.get_commit_id(), gha_env["GITHUB_SHA"])
             self.assertEquals(manager.is_pull_request(), True)
+
+        gha_env = {"GITHUB_ACTIONS": "true",
+                   "GITHUB_REF": "refs/heads/testing",
+                   "GITHUB_EVENT_NAME": "push"}
+        with tools.environment_append(gha_env):
+            manager = CIManager(self.printer)
+            self.assertEquals(manager.get_branch(), "testing")
 
     def test_build_policy(self):
         # Travis


### PR DESCRIPTION
Changelog: (Fix): `GitHubActionsManager` CI manager was detecting Github Actions branches as `refs/heads/<branchname>`

See https://github.com/trassir/conan-center-index/runs/497421002#step:5:110 for example:
```
Version: 0.31.2
 >> CI detected: GitHub Actions
WARN: Remotes registry file missing, creating default one in C:\Users\runneradmin\.conan\remotes.json

 >> Branch detected
   >> refs/heads/cpt-fork
```

The same slice is already present in `AzurePipelinesManager` though, so it might be a better idea to have some common function for cleaning up any ref instead.

- [ ] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan-package-tools/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008) style guides for Python code.
