### PR TITLE
Fix appveyor example with regards to Python3

### DIFF
--- a/README.md
+++ b/README.md
@@ -772,7 +772,7 @@ This is very similar to Travis CI. With the same **build.py** script we have the
     build: false
 
     environment:
-        PYTHON: "C:\\Python27"
+        PYTHON_HOME: "C:\\Python27"
         PYTHON_VERSION: "2.7.8"
         PYTHON_ARCH: "32"
 
@@ -793,7 +793,7 @@ This is very similar to Travis CI. With the same **build.py** script we have the
 
 
     install:
-      - set PATH=%PYTHON%/Scripts/;%PATH%
+      - set PATH=%PYTHON_HOME%;%PYTHON_HOME%/Scripts/;%PATH%
       - python -Wignore -m pip install conan_package_tools --upgrade
       - conan user # It creates the conan data directory
 

--- a/README.md
+++ b/README.md
@@ -772,8 +772,8 @@ This is very similar to Travis CI. With the same **build.py** script we have the
     build: false
 
     environment:
-        PYTHON_HOME: "C:\\Python27"
-        PYTHON_VERSION: "2.7.8"
+        PYTHON_HOME: "C:\\Python38"
+        PYTHON_VERSION: "3.8.0"
         PYTHON_ARCH: "32"
 
         CONAN_USERNAME: "lasote"

--- a/README.md
+++ b/README.md
@@ -793,8 +793,8 @@ This is very similar to Travis CI. With the same **build.py** script we have the
 
 
     install:
-      - set PATH=%PATH%;%PYTHON%/Scripts/
-      - pip.exe install conan_package_tools --upgrade
+      - set PATH=%PYTHON%/Scripts/;%PATH%
+      - python -Wignore -m pip install conan_package_tools --upgrade
       - conan user # It creates the conan data directory
 
     test_script:


### PR DESCRIPTION
Changelog: Fix appveyor example with regards to Python3

- [ ] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.

 The appveyor example caused errors with on Appveyor VS2017 image where both Python2 and Python3 are installed and Python3 is the default one. The problems seems to be in the poor support of Python2 while Python3 works well.
Python2 was selected by default because it was in PATH while Python3 weren't regardless of env variables. 
The fixes to PATH in these PR should fix it. 
I tested it with one of packages with just slightly different PATH. But PYTHON_HOME was still in the first place. It worked properly.

I'd also update the matrix with VS2019. But it's another story :)

- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan-package-tools/blob/develop/.github/CONTRIBUTING.md).
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008) style guides for Python code.
