### PR TITLE
Fix issue in packager script when options are None

### DIFF
--- a/cpt/packager.py
+++ b/cpt/packager.py
@@ -498,6 +498,8 @@ class ConanMultiPackager(object):
                 raw_options_for_building.remove(raw_option)
         if raw_options_for_building and conanfile:
             # get option and its values
+            if conanfile.options is None:
+                conanfile.options = {}
             cloned_options = copy.copy(conanfile.options)
             for key, value in conanfile.options.items():
                 if key == "shared" and shared_option_name:


### PR DESCRIPTION
Changelog: (Bugfix): Fix an issue where if no options exist in a conanfile, and the parameter `build_all_options_values` is provided to the function `add_common_builds()` it would error out and fail

Further Details:
If you have two conanfiles, one for package `foo` and one for package `bar`, and if `bar` specifies `options = {"xyz": [True, False]}` but `foo` simply doesn't specify the options attribute at all. If you then go to run the `ConanMultiPackager` on `foo` it will error out when you try to do the following
```
builder = ConanMultiPackager()
builder.add_common_builds(build_all_options_values=["bar:xyz"])
```
due to the fact that `foo.options == None` and trying to call `for key, value in foo.options.items()` on a NoneType object yields the error 
```
Traceback (most recent call last):
  File "build.py", line 19, in <module>
    builder.add_common_builds(build_all_options_values=["bar:xyz"])
  File "c:\users\dr\appdata\local\programs\python\python38\lib\site-packages\cpt\packager.py", line 502, in add_common_builds
    for key, value in conanfile.options.items():
AttributeError: 'NoneType' object has no attribute 'items'
```

- [ ] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan-package-tools/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008) style guides for Python code.
