### PR TITLE
Pass cwd to DockerCreateRunner, #447

### DIFF
--- a/cpt/packager.py
+++ b/cpt/packager.py
@@ -704,7 +704,8 @@ class ConanMultiPackager(object):
                                        lockfile=self.lockfile,
                                        force_selinux=self.force_selinux,
                                        skip_recipe_export=skip_recipe_export,
-                                       update_dependencies=self.update_dependencies)
+                                       update_dependencies=self.update_dependencies,
+                                       cwd=self.cwd)
 
                 r.run(pull_image=not pulled_docker_images[docker_image],
                       docker_entry_script=self.docker_entry_script)

--- a/cpt/runner.py
+++ b/cpt/runner.py
@@ -184,7 +184,8 @@ class DockerCreateRunner(object):
                  force_selinux=None,
                  skip_recipe_export=False,
                  update_dependencies=False,
-                 lockfile=None):
+                 lockfile=None,
+                 cwd=None):
 
         self.printer = printer or Printer()
         self._upload = upload
@@ -219,6 +220,7 @@ class DockerCreateRunner(object):
         self._force_selinux = force_selinux
         self._skip_recipe_export = skip_recipe_export
         self._update_dependencies = update_dependencies
+        self._cwd = cwd or os.getcwd()
 
     def _pip_update_conan_command(self):
         commands = []
@@ -298,7 +300,7 @@ class DockerCreateRunner(object):
         command = ('%s docker run --rm -v "%s:%s/project%s" %s %s %s %s %s '
                    '"%s cd project && '
                    '%s run_create_in_docker "' % (self._sudo_docker_command,
-                                                  os.getcwd(),
+                                                  self._cwd,
                                                   self._docker_conan_home,
                                                   volume_options,
                                                   env_vars_text,

--- a/cpt/test/unit/packager_test.py
+++ b/cpt/test/unit/packager_test.py
@@ -1078,3 +1078,19 @@ class AppTest(unittest.TestCase):
             builder.add_common_builds()
             builder.run()
             self.assertEquals("couse.lock", self.conan_api.calls[-1].kwargs["lockfile"])
+
+    def test_docker_cwd(self):
+        cwd = os.path.join(os.getcwd(), 'subdir')
+        self.packager = ConanMultiPackager(username="lasote",
+                                           channel="mychannel",
+                                           runner=self.runner,
+                                           conan_api=self.conan_api,
+                                           gcc_versions=["9"],
+                                           use_docker=True,
+                                           reference="zlib/1.2.11",
+                                           ci_manager=self.ci_manager,
+                                           cwd=cwd)
+
+        self._add_build(1, "gcc", "9")
+        self.packager.run_builds(1, 1)
+        self.assertIn('docker run --rm -v "%s:/home/conan/project"' % cwd, self.runner.calls[4])

--- a/cpt/test/unit/packager_test.py
+++ b/cpt/test/unit/packager_test.py
@@ -1093,4 +1093,4 @@ class AppTest(unittest.TestCase):
 
         self._add_build(1, "gcc", "9")
         self.packager.run_builds(1, 1)
-        self.assertIn('docker run --rm -v "%s:/home/conan/project"' % cwd, self.runner.calls[4])
+        self.assertIn('docker run --rm -v "%s:%s/project"' % (cwd, self.packager.docker_conan_home), self.runner.calls[4])


### PR DESCRIPTION
Fixes PR #447

The patch allows building packages using Docker in non-flat repositories
with specifying cwd.

Example:

    builder = ConanMultiPackager(cwd=os.path.join(os.getcwd(), 'recipes', 'foobar'))

Changelog: Feature: Pass cwd to DockerCreateRunner

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan-package-tools/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008) style guides for Python code.
