### PR TITLE
Remove all Carriage Returns in escape_env()

### DIFF
--- a/cpt/runner.py
+++ b/cpt/runner.py
@@ -367,7 +367,7 @@ def unscape_env(text):
 def escape_env(text):
     if not text:
         return text
-    return text.replace("\n", "@@").replace('"', '||')
+    return text.replace("\r", "").replace("\n", "@@").replace('"', '||')
 
 
 class PrintRunner(object):


### PR DESCRIPTION

Changelog: Fix: Remove Carriage Returns in text that is encoded in env variables

fixes #543.

Any Carriage Return in the encoded text will cause problems when
printing the string. The old version would leave the Carriage Return
and just replace the Line Feed in text that uses CR/LF as line ending.

From my point of view all major operating systems use at least Line Feed in line endings. So it should be safe to remove all Carriage Returns in strings when they are encoded in the escape_env() method.

For a more robust implementation it might even be better to remove all non-printable characters.

- [X ] Refer to the issue that supports this Pull Request.
- [ X] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ X] I've read the [Contributing guide](https://github.com/conan-io/conan-package-tools/blob/develop/.github/CONTRIBUTING.md).
- [ X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008) style guides for Python code.
