### PR TITLE
Force package upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -1100,6 +1100,7 @@ Using **CONAN_CLANG_VERSIONS** env variable in Travis ci or Appveyor:
 - **upload_only_when_tag**: Will try to upload only if the branch is a tag. Default [False]
 - **upload_only_recipe**: If defined, will try to upload **only** the recipes. The built packages will **not** be uploaded. Default [False]
 - **upload_dependencies**: Will try to upload dependencies to your remote. Default [False]
+- **upload_force**: Will try to force uploaded all packages. Default [True]
 - **build_types**: List containing specific build types. Default ["Release", "Debug"]
 - **cppstds**: List containing specific cpp standards. Default None
 - **skip_check_credentials**: Conan will skip checking the user credentials before building the packages. And if no user/remote is specified, will try to upload with the
@@ -1220,6 +1221,7 @@ This is especially useful for CI integration.
 - **CONAN_UPLOAD_ONLY_WHEN_TAG**: If defined, will try to upload the packages only when the current branch is a tag.
 - **CONAN_UPLOAD_ONLY_RECIPE**: If defined, will try to upload **only** the recipes. The built packages will **not** be uploaded.
 - **CONAN_UPLOAD_DEPENDENCIES**: If defined, will try to upload the listed package dependencies to your remote.
+- **CONAN_UPLOAD_FORCE**: If defined, will try to force upload all packages. Default is `True`.
 
 - **CONAN_SKIP_CHECK_CREDENTIALS**: Conan will skip checking the user credentials before building the packages. And if no user/remote is specified, will try to upload with the
   already stored credentiales in the local cache. Default [False]

--- a/cpt/packager.py
+++ b/cpt/packager.py
@@ -668,6 +668,7 @@ class ConanMultiPackager(object):
                                  test_folder=self.test_folder,
                                  config_url=self.config_url,
                                  config_args=self.config_args,
+                                 upload_dependencies=self.upload_dependencies,
                                  conanfile=self.conanfile,
                                  lockfile=self.lockfile,
                                  skip_recipe_export=skip_recipe_export,

--- a/cpt/packager.py
+++ b/cpt/packager.py
@@ -21,7 +21,7 @@ from cpt.printer import Printer
 from cpt.profiles import get_profiles, save_profile_to_tmp
 from cpt.remotes import RemotesManager
 from cpt.runner import CreateRunner, DockerCreateRunner
-from cpt.tools import get_bool_from_env
+from cpt.tools import get_bool_from_env, get_custom_bool_from_env
 from cpt.tools import split_colon_env
 from cpt.uploader import Uploader
 
@@ -114,6 +114,7 @@ class ConanMultiPackager(object):
                  upload_only_when_stable=None,
                  upload_only_when_tag=None,
                  upload_only_recipe=None,
+                 upload_force=None,
                  build_types=None,
                  cppstds=None,
                  skip_check_credentials=False,
@@ -184,10 +185,12 @@ class ConanMultiPackager(object):
             self.upload_only_when_tag = get_bool_from_env("CONAN_UPLOAD_ONLY_WHEN_TAG")
 
         self.upload_only_recipe = upload_only_recipe or get_bool_from_env("CONAN_UPLOAD_ONLY_RECIPE")
+        self.upload_force = upload_force if upload_force is not None \
+                            else get_custom_bool_from_env("CONAN_UPLOAD_FORCE", True)
 
         self.remotes_manager.add_remotes_to_conan()
         self.uploader = Uploader(self.conan_api, self.remotes_manager, self.auth_manager,
-                                 self.printer, self.upload_retry)
+                                 self.printer, self.upload_retry, self.upload_force)
 
         self._builds = []
         self._named_builds = {}
@@ -665,7 +668,6 @@ class ConanMultiPackager(object):
                                  test_folder=self.test_folder,
                                  config_url=self.config_url,
                                  config_args=self.config_args,
-                                 upload_dependencies=self.upload_dependencies,
                                  conanfile=self.conanfile,
                                  lockfile=self.lockfile,
                                  skip_recipe_export=skip_recipe_export,
@@ -687,6 +689,7 @@ class ConanMultiPackager(object):
                                        upload=self._upload_enabled(),
                                        upload_retry=self.upload_retry,
                                        upload_only_recipe=self.upload_only_recipe,
+                                       upload_force=self.upload_force,
                                        runner=self.runner,
                                        docker_shell=self.docker_shell,
                                        docker_conan_home=self.docker_conan_home,

--- a/cpt/run_in_docker.py
+++ b/cpt/run_in_docker.py
@@ -24,7 +24,8 @@ def run():
 
     upload_retry = os.getenv("CPT_UPLOAD_RETRY")
     upload_only_recipe = os.getenv("CPT_UPLOAD_ONLY_RECIPE")
-    uploader = Uploader(conan_api, remotes_manager, auth_manager, printer, upload_retry)
+    upload_force = os.getenv("CPT_UPLOAD_FORCE")
+    uploader = Uploader(conan_api, remotes_manager, auth_manager, printer, upload_retry, upload_force)
     build_policy = unscape_env(os.getenv("CPT_BUILD_POLICY"))
     test_folder = unscape_env(os.getenv("CPT_TEST_FOLDER"))
     reference = ConanFileReference.loads(os.getenv("CONAN_REFERENCE"))

--- a/cpt/runner.py
+++ b/cpt/runner.py
@@ -170,6 +170,7 @@ class DockerCreateRunner(object):
                  docker_image_skip_pull=False,
                  always_update_conan_in_docker=False,
                  upload=False, upload_retry=None, upload_only_recipe=None,
+                 upload_force=None,
                  runner=None,
                  docker_shell="", docker_conan_home="",
                  docker_platform_param="", docker_run_options="",
@@ -192,6 +193,7 @@ class DockerCreateRunner(object):
         self._upload = upload
         self._upload_retry = upload_retry
         self._upload_only_recipe = upload_only_recipe
+        self._upload_force = upload_force
         self._reference = reference
         self._conan_pip_package = conan_pip_package
         self._build_policy = build_policy
@@ -343,6 +345,7 @@ class DockerCreateRunner(object):
         ret["CPT_UPLOAD_ENABLED"] = self._upload
         ret["CPT_UPLOAD_RETRY"] = self._upload_retry
         ret["CPT_UPLOAD_ONLY_RECIPE"] = self._upload_only_recipe
+        ret["CPT_UPLOAD_FORCE"] = self._upload_force
         ret["CPT_BUILD_POLICY"] = escape_env(self._build_policy)
         ret["CPT_TEST_FOLDER"] = escape_env(self._test_folder)
         ret["CPT_CONFIG_URL"] = escape_env(self._config_url)

--- a/cpt/test/integration/docker_test.py
+++ b/cpt/test/integration/docker_test.py
@@ -53,7 +53,7 @@ class Pkg(ConanFile):
                                        "CONAN_PASSWORD": "demo"}):
 
             self.packager = ConanMultiPackager(channel="mychannel",
-                                               gcc_versions=["6"],
+                                               gcc_versions=["8"],
                                                archs=["x86", "x86_64"],
                                                build_types=["Release"],
                                                reference=unique_ref,
@@ -96,7 +96,7 @@ class Pkg(ConanFile):
                                        "CONAN_DOCKER_IMAGE_SKIP_UPDATE": "TRUE",
                                        "CONAN_UPLOAD_ONLY_WHEN_STABLE": "1"}):
             self.packager = ConanMultiPackager(channel="mychannel",
-                                               gcc_versions=["6"],
+                                               gcc_versions=["8"],
                                                archs=["x86", "x86_64"],
                                                build_types=["Release"],
                                                reference=unique_ref,

--- a/cpt/tools.py
+++ b/cpt/tools.py
@@ -6,6 +6,11 @@ def get_bool_from_env(var_name):
     return str(val).lower() not in ("0", "none", "false")
 
 
+def get_custom_bool_from_env(var_name, default=None):
+    val = os.getenv(var_name, default)
+    return str(val).lower() in ('true', 'on', 'ok', 'y', 'yes', '1')
+
+
 def split_colon_env(varname):
     if os.getenv(varname) is None:
         return None

--- a/cpt/uploader.py
+++ b/cpt/uploader.py
@@ -1,4 +1,5 @@
 from conans.model.version import Version
+from conans.client.cmd.uploader import UPLOAD_POLICY_FORCE
 
 from cpt import get_client_version
 
@@ -52,4 +53,5 @@ class Uploader(object):
                 self.conan_api.upload(str(reference),
                                       all_packages=all_packages,
                                       remote_name=remote_name,
+                                      policy=UPLOAD_POLICY_FORCE,
                                       retry=int(self._upload_retry))

--- a/cpt/uploader.py
+++ b/cpt/uploader.py
@@ -6,12 +6,13 @@ from cpt import get_client_version
 
 class Uploader(object):
 
-    def __init__(self, conan_api, remote_manager, auth_manager, printer, upload_retry):
+    def __init__(self, conan_api, remote_manager, auth_manager, printer, upload_retry, force):
         self.conan_api = conan_api
         self.remote_manager = remote_manager
         self.auth_manager = auth_manager
         self.printer = printer
         self._upload_retry = upload_retry
+        self._force = force
         if not self._upload_retry:
             self._upload_retry = 0
 
@@ -40,18 +41,19 @@ class Uploader(object):
                 self.conan_api.upload(str(reference),
                                       package=package_id,
                                       remote=remote_name,
-                                      force=True,
+                                      force=self._force,
                                       retry=int(self._upload_retry))
             elif client_version < Version("1.8.0"):
                 self.conan_api.upload(str(reference),
                                       package=package_id,
                                       remote_name=remote_name,
-                                      force=True,
+                                      force=self._force,
                                       retry=int(self._upload_retry))
             else:
                 all_packages = package_id != None
+                policy = UPLOAD_POLICY_FORCE if self._force else None
                 self.conan_api.upload(str(reference),
                                       all_packages=all_packages,
                                       remote_name=remote_name,
-                                      policy=UPLOAD_POLICY_FORCE,
+                                      policy=policy,
                                       retry=int(self._upload_retry))


### PR DESCRIPTION
As Conan API changed its API from time to time, some parameters are not the same. Force is one of them. Now it's a build policy in upload method, and not an exclusive parameter anymore.

This PR adds force build policy for upload execution, which is the normal flow, following older API versions. The Force is an option now, but by default it will follow the old behavior, force all uploads.

Changelog: Fix: Force package upload for all Conan versions

fixes #547 

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan-package-tools/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008) style guides for Python code.
