### PR TITLE
Fix pyreq_loader minimal version

### DIFF
--- a/cpt/packager.py
+++ b/cpt/packager.py
@@ -52,12 +52,12 @@ def load_cf_class(path, conan_api):
             conan_api.create_app()
         remotes = conan_api.app.cache.registry.load_remotes()
         conan_api.app.python_requires.enable_remotes(remotes=remotes)
-        conan_api.app.pyreq_loader.enable_remotes(remotes=remotes)
         if client_version < Version("1.20.0"):
             return conan_api.app.loader.load_class(path)
         elif client_version < Version("1.21.0"):
             return conan_api.app.loader.load_basic(path)
         else:
+            conan_api.app.pyreq_loader.enable_remotes(remotes=remotes)
             return conan_api.app.loader.load_named(path, None, None, None, None)
 
 


### PR DESCRIPTION
The Conan App member `pyreq_loader` was added on Conan 1.21.0:

https://github.com/conan-io/conan/compare/1.20.0...1.21.0#diff-c15f4aacf65aa58b31a041bac63e4dd7337355d9ec44a8f32b2a5815d5eb5ea9R191

Changelog: Fix: pyreq_loader requires Conan 1.21.0 or higher

fixes #521 

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan-package-tools/blob/develop/.github/CONTRIBUTING.md).
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008) style guides for Python code.
