### PR TITLE
Config URL should run before loading profiles 

### DIFF
--- a/cpt/packager.py
+++ b/cpt/packager.py
@@ -24,6 +24,7 @@ from cpt.runner import CreateRunner, DockerCreateRunner
 from cpt.tools import get_bool_from_env
 from cpt.tools import split_colon_env
 from cpt.uploader import Uploader
+from cpt.config import ConfigManager
 
 
 def load_cf_class(path, conan_api):
@@ -648,6 +649,8 @@ class ConanMultiPackager(object):
                 self.printer.print_message("Using specified default "
                                            "base profile: %s" % base_profile_name)
                 self.printer.print_message("**************************************************")
+                if self.config_url:
+                    ConfigManager(self.conan_api, self.printer).install(url=self.config_url, args=self.config_args)
 
             profile_text, base_profile_text = get_profiles(self.client_cache, build,
                                                            base_profile_name)

--- a/cpt/run_in_docker.py
+++ b/cpt/run_in_docker.py
@@ -3,6 +3,7 @@ import os
 from conans import tools
 from conans.client.conan_api import Conan
 from conans.model.ref import ConanFileReference
+from conans.model.version import Version
 
 from cpt.auth import AuthManager
 from cpt.printer import Printer
@@ -10,11 +11,18 @@ from cpt.profiles import save_profile_to_tmp
 from cpt.remotes import RemotesManager
 from cpt.runner import CreateRunner, unscape_env
 from cpt.uploader import Uploader
+from cpt import get_client_version
 
 
 def run():
-    # Get all from environ
-    conan_api, client_cache, _ = Conan.factory()
+    conan_version = get_client_version()
+    if conan_version < Version("1.18.0"):
+        conan_api, client_cache, _ = Conan.factory()
+    else:
+        conan_api, _, _ = Conan.factory()
+        conan_api.create_app()
+        client_cache = conan_api.app.cache
+
     printer = Printer()
 
     remotes_manager = RemotesManager(conan_api, printer)

--- a/cpt/test/integration/docker_test.py
+++ b/cpt/test/integration/docker_test.py
@@ -3,6 +3,7 @@ import unittest
 import time
 import textwrap
 
+
 from conans import tools
 from conans.model.ref import ConanFileReference
 from conans.model.version import Version
@@ -235,6 +236,38 @@ class Pkg(ConanFile):
                 self.packager.run()
                 self.assertIn("Error updating the image", str(raised.exception))
                 self.assertIn("foobar install conan_package_tools", str(raised.exception))
+
+    @unittest.skipUnless(is_linux_and_have_docker(), "Requires Linux and Docker")
+    def test_docker_base_profile(self):
+        conanfile = textwrap.dedent("""
+                from conans import ConanFile
+
+                class Pkg(ConanFile):
+
+                    def build(self):
+                        pass
+            """)
+
+        self.save_conanfile(conanfile)
+        with tools.environment_append({"CONAN_DOCKER_RUN_OPTIONS": "--network=host -v{}:/tmp/cpt".format(self.root_project_folder),
+                                       "CONAN_DOCKER_ENTRY_SCRIPT": "pip install -U /tmp/cpt",
+                                       "CONAN_DOCKER_IMAGE": "conanio/gcc8",
+                                       "CONAN_USE_DOCKER": "1",
+                                       "CONAN_REFERENCE": "foo/0.0.1@bar/testing",
+                                       "CONAN_DOCKER_IMAGE_SKIP_UPDATE": "TRUE",
+                                       "CONAN_FORCE_SELINUX": "TRUE",
+                                       "CONAN_DOCKER_USE_SUDO": "FALSE",
+                                       "CONAN_DOCKER_SHELL": "/bin/bash -c",
+                                       }):
+            self.packager = ConanMultiPackager(gcc_versions=["8"],
+                                               archs=["x86_64"],
+                                               build_types=["Release"],
+                                               config_url="https://github.com/bincrafters/bincrafters-config.git",
+                                               out=self.output.write)
+            self.packager.add({})
+            self.packager.run(base_profile_name="linux-gcc8-amd64")
+            self.assertIn('Using specified default base profile: linux-gcc8-amd64', self.output)
+            self.assertIn('-e CPT_BASE_PROFILE_NAME="linux-gcc8-amd64"', self.output)
 
     @unittest.skipUnless(is_linux_and_have_docker(), "Requires Linux and Docker")
     def test_docker_hidden_password(self):


### PR DESCRIPTION
When `base_profile_name` is configured and it depends from a remote config folder, which should be solved by `config_url`, CPT will fail, because it tries to load that profile file first.

This PR fixes configuration/profile order, and introduces ConanApp (Conan >=1.18.0) correctly for profile cache when running Docker.

Changelog: Fix: Config URL should run before loading profiles 

fixes #441

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan-package-tools/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008) style guides for Python code.
Signed-off-by: Uilian Ries <uilianries@gmail.com>