### PR TITLE
use get_bool_from_env from a boolean env var

### DIFF
--- a/cpt/packager.py
+++ b/cpt/packager.py
@@ -231,7 +231,7 @@ class ConanMultiPackager(object):
         self._docker_image = docker_image or os.getenv("CONAN_DOCKER_IMAGE", None)
 
         # If CONAN_DOCKER_IMAGE is specified, then use docker is True
-        self.use_docker = (use_docker or os.getenv("CONAN_USE_DOCKER", False) or
+        self.use_docker = (use_docker or get_bool_from_env("CONAN_USE_DOCKER") or
                            self._docker_image is not None)
 
         self.docker_conan_home = docker_conan_home or os.getenv("CONAN_DOCKER_HOME", None)


### PR DESCRIPTION
Changelog: Fix: read CONAN_USE_DOCKER is read as an str

fixes #573

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan-package-tools/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008) style guides for Python code.
