### PR TITLE
Use user and channel of recipe if not specified

### DIFF
--- a/cpt/packager.py
+++ b/cpt/packager.py
@@ -167,7 +167,18 @@ class ConanMultiPackager(object):
 
         self.ci_manager = ci_manager or CIManager(self.printer)
         self.remotes_manager = RemotesManager(self.conan_api, self.printer, remotes, upload)
+
+        #fix: load conan file early
+        self.conanfile = conanfile or os.getenv("CONAN_CONANFILE", "conanfile.py")
+        conanfile = load_cf_class(os.path.join(self.cwd, self.conanfile), self.conan_api)
+        user, channel = conanfile.user, conanfile.channel
+
         self.username = username or os.getenv("CONAN_USERNAME", None)
+
+        #fix: set username
+        if self.username is None:
+            if user:
+                self.username = user
 
         self.skip_check_credentials = skip_check_credentials or get_bool_from_env("CONAN_SKIP_CHECK_CREDENTIALS")
 
@@ -212,7 +223,11 @@ class ConanMultiPackager(object):
         self.stable_channel = self.stable_channel.rstrip()
         self.partial_reference = reference or os.getenv("CONAN_REFERENCE", None)
         self.channel = self._get_specified_channel(channel, reference)
-        self.conanfile = conanfile or os.getenv("CONAN_CONANFILE", "conanfile.py")
+
+        #fix: set channel
+        if self.channel is None:
+            if channel:
+                self.channel = channel
 
         if self.partial_reference:
             if "@" in self.partial_reference:

--- a/cpt/packager.py
+++ b/cpt/packager.py
@@ -12,6 +12,7 @@ from conans.client.conan_api import Conan
 from conans.client.runner import ConanRunner
 from conans.model.ref import ConanFileReference
 from conans.model.version import Version
+from conans.errors import ConanException
 
 from cpt import get_client_version
 from cpt.auth import AuthManager
@@ -172,8 +173,15 @@ class ConanMultiPackager(object):
         self.conanfile = conanfile or os.getenv("CONAN_CONANFILE", "conanfile.py")
         conanfile = load_cf_class(os.path.join(self.cwd, self.conanfile), self.conan_api)
 
-        recipe_user = conanfile.user if hasattr(conanfile, "user") else None
-        recipe_channel = conanfile.channel if hasattr(conanfile, "channel") else None
+        try:
+            recipe_user = conanfile.user
+        except ConanException:
+            recipe_user = None
+
+        try:
+            recipe_channel = conanfile.channel
+        except ConanException:
+            recipe_channel = None
 
         self.username = username or os.getenv("CONAN_USERNAME", None)
 

--- a/cpt/packager.py
+++ b/cpt/packager.py
@@ -171,14 +171,15 @@ class ConanMultiPackager(object):
         #fix: load conan file early
         self.conanfile = conanfile or os.getenv("CONAN_CONANFILE", "conanfile.py")
         conanfile = load_cf_class(os.path.join(self.cwd, self.conanfile), self.conan_api)
-        user, channel = conanfile.user, conanfile.channel
+
+        recipe_user = conanfile.user if hasattr(conanfile, "user") else None
+        recipe_channel = conanfile.channel if hasattr(conanfile, "channel") else None
 
         self.username = username or os.getenv("CONAN_USERNAME", None)
 
         #fix: set username
-        if self.username is None:
-            if user:
-                self.username = user
+        if self.username is None and recipe_user:
+            self.username = recipe_user
 
         self.skip_check_credentials = skip_check_credentials or get_bool_from_env("CONAN_SKIP_CHECK_CREDENTIALS")
 
@@ -225,9 +226,8 @@ class ConanMultiPackager(object):
         self.channel = self._get_specified_channel(channel, reference)
 
         #fix: set channel
-        if self.channel is None:
-            if channel:
-                self.channel = channel
+        if self.channel is None and recipe_channel:
+            self.channel = recipe_channel
 
         if self.partial_reference:
             if "@" in self.partial_reference:


### PR DESCRIPTION
Changelog: (Feature): Capture username and channel from conanfile.py

Closes #602 

In case user or channel are not given to ConanMultiPackager via parameter or environment variable, both are taken from the recipe to build. The overcomes the necessity to repeat user and channel of the recipe in the build script. Furthermore, it enables the realization of custom channel-strategies in the recipe.

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan-package-tools/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008) style guides for Python code.
