### PR TITLE
Feature/build profile

### DIFF
--- a/cpt/packager.py
+++ b/cpt/packager.py
@@ -709,6 +709,8 @@ class ConanMultiPackager(object):
                 r.run()
                 self._packages_summary.append({"configuration":  build, "package" : r.results})
             else:
+                if not base_profile_build_text:
+                    profile_build_text = None
                 docker_image = self._get_docker_image(build)
                 r = DockerCreateRunner(profile_text, base_profile_text, base_profile_name,
                                        build.reference,

--- a/cpt/profiles.py
+++ b/cpt/profiles.py
@@ -15,7 +15,11 @@ def get_profiles(client_cache, build_config, base_profile_name=None, is_build_pr
         base_profile_path = os.path.join(client_cache.profiles_path, base_profile_name)
         base_profile_text = tools.load(base_profile_path)
     base_profile_name = base_profile_name or "default"
-    tmp = """
+
+    if is_build_profile:
+        profile_text = "include(%s)" % (base_profile_name)
+    else:
+        tmp = """
 include(%s)
 
 [settings]
@@ -28,27 +32,25 @@ include(%s)
 %s
 """
 
-    def pairs_lines(items):
-        return "\n".join(["%s=%s" % (k, v) for k, v in items])
-    if is_build_profile:
-        settings=""
-        options=""
-    else:
+        def pairs_lines(items):
+            return "\n".join(["%s=%s" % (k, v) for k, v in items])
+
         settings = pairs_lines(sorted(build_config.settings.items()))
         options = pairs_lines(build_config.options.items())
-    env_vars = pairs_lines(build_config.env_vars.items())
-    br_lines = ""
-    for pattern, build_requires in build_config.build_requires.items():
-        br_lines += "\n".join(["%s:%s" % (pattern, br) for br in build_requires])
+        env_vars = pairs_lines(build_config.env_vars.items())
+        br_lines = ""
+        for pattern, build_requires in build_config.build_requires.items():
+            br_lines += "\n".join(["%s:%s" % (pattern, br) for br in build_requires])
 
-    if os.getenv("CONAN_BUILD_REQUIRES"):
-        brs = os.getenv("CONAN_BUILD_REQUIRES").split(",")
-        brs = ['*:%s' % br.strip() if ":" not in br else br for br in brs]
-        if br_lines:
-            br_lines += "\n"
-        br_lines += "\n".join(brs)
+        if os.getenv("CONAN_BUILD_REQUIRES"):
+            brs = os.getenv("CONAN_BUILD_REQUIRES").split(",")
+            brs = ['*:%s' % br.strip() if ":" not in br else br for br in brs]
+            if br_lines:
+                br_lines += "\n"
+            br_lines += "\n".join(brs)
 
-    profile_text = tmp % (base_profile_name, settings, options, env_vars, br_lines)
+        profile_text = tmp % (base_profile_name, settings, options, env_vars, br_lines)
+
     return profile_text, base_profile_text
 
 


### PR DESCRIPTION
Changelog: (Fix): When using Docker: only pass a build profile if it has been explicitly specified

By default the ´´´default´´´ profile has been used if no build profile was given while creating the ´´´ConanMultiPackager´´´ for Docker. This causes Conan to always be run with a build profile, which is different to how it is run when not using Docker. Conan also behaves differently for some use cases when a build profile is given.

This pull request also strips down the build profile text passed to the Docker container via environment variables to a bare minimum. The reason for this is explained in the commit message (this change can also be reverted if I missed something)

fixes #595

- [x ] Refer to the issue that supports this Pull Request.
- [x ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x ] I've read the [Contributing guide](https://github.com/conan-io/conan-package-tools/blob/develop/.github/CONTRIBUTING.md).
- [ x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008) style guides for Python code.
