### PR TITLE
do not change the order of the remotes

### DIFF
--- a/cpt/remotes.py
+++ b/cpt/remotes.py
@@ -76,9 +76,9 @@ class RemotesManager(object):
         for r in self._remotes:
             if self._upload and r.url == self._upload.url:
                 name = self._add_remote(self._upload.url, self._upload.use_ssl,
-                                        self._upload.name, insert=-1)
+                                        self._upload.name, insert=None)
             else:
-                name = self._add_remote(r.url, r.use_ssl, r.name, insert=-1)
+                name = self._add_remote(r.url, r.use_ssl, r.name, insert=None)
 
             if name != r.name:    # Already existing url, keep it
                 _added_remotes.append(Remote(r.url, r.use_ssl, name))
@@ -87,7 +87,7 @@ class RemotesManager(object):
 
         if self._upload and not self.upload_remote_in_remote_list():
             name = self._add_remote(self._upload.url, self._upload.use_ssl,
-                                    self._upload.name, insert=-1)
+                                    self._upload.name, insert=None)
             if name != self._upload.name:  # Already existing url, keep it
                 self._upload = Remote(self._upload.url, self._upload.use_ssl, name)
 


### PR DESCRIPTION
Changelog: (Bugfix):

Fixes #613 

- [x] I've read the [Contributing guide](https://github.com/conan-io/conan-package-tools/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008) style guides for Python code.

Do not change the order of the remotes by using the default value from the Conan API instead of -1 in `add_remotes_to_conan -> _add_remote`

Probably in Remotesmanager._add_remote the default argument of `insert` should be changed to `None` instead of `False`. The ConanAPI uses `None` as a the default value.
The default  value `False` gets treated differently then  `None` . `False ` gets interpreted as not  `None` , hence we go in the insert_by_index case. `index = int(False) = 0`` Hence it will put always to the beginning.
The current version uses `index=-1`` which does *not* push to the end. It pushes to `end -1`, i.e. 1 BEFORE the last element. 
`None` has it's own handling and adds the remote to the end of the remotes OrderedDict which should be the correct behavior [see remote_registry.py : Remotes._remotes].